### PR TITLE
Enhance RSS feed metadata and browser preview

### DIFF
--- a/site/public/rss/styles.xsl
+++ b/site/public/rss/styles.xsl
@@ -130,8 +130,28 @@ This file is in BETA. Please test and contribute to the discussion:
                 </a>
               </h3>
               <small class="text-gray">
-                Published: <xsl:value-of select="pubDate" />
+                <xsl:if test="author">
+                  By <xsl:value-of select="author" />
+                </xsl:if>
+                <xsl:if test="pubDate">
+                  <xsl:if test="author"> · </xsl:if>
+                  <xsl:value-of select="pubDate" />
+                </xsl:if>
               </small>
+              <xsl:if test="description != ''">
+                <p style="margin-top: 4px; margin-bottom: 4px; color: #586069;">
+                  <xsl:value-of select="description"/>
+                </p>
+              </xsl:if>
+              <xsl:if test="category">
+                <div style="margin-top: 4px;">
+                  <xsl:for-each select="category">
+                    <span style="display: inline-block; padding: 2px 8px; margin-right: 4px; font-size: 12px; border-radius: 12px; background: #f1f8ff; color: #0366d6;">
+                      <xsl:value-of select="."/>
+                    </span>
+                  </xsl:for-each>
+                </div>
+              </xsl:if>
             </div>
           </xsl:for-each>
         </div>

--- a/site/src/pages/rss.xml.ts
+++ b/site/src/pages/rss.xml.ts
@@ -2,30 +2,60 @@ import rss from "@astrojs/rss";
 import { getCollection } from "astro:content";
 import type { APIContext } from "astro";
 import { REPO_URL, withBase, BASE_URL } from "@/config";
+import { loadAuthorsCache } from "@/lib/registry";
 
 export async function GET(context: APIContext) {
   const notebooks = await getCollection("notebooks");
+  const authorsCache = loadAuthorsCache();
   const siteUrl = context.site!;
   // Include base path in site URL for correct channel link
   const siteWithBase = new URL(BASE_URL, siteUrl).href;
+  const feedUrl = new URL(withBase("/rss.xml"), siteUrl).href;
+
+  // Sort by date descending (undated entries last)
+  const sorted = [...notebooks].sort((a, b) => {
+    const da = a.data.date ? new Date(a.data.date).getTime() : 0;
+    const db = b.data.date ? new Date(b.data.date).getTime() : 0;
+    return db - da;
+  });
+
+  // Derive lastBuildDate from most recent entry
+  const latestDate = sorted.find((n) => n.data.date)?.data.date;
+  const lastBuildDate = latestDate
+    ? new Date(latestDate).toUTCString()
+    : new Date().toUTCString();
 
   return rss({
     title: "Forgebook",
     description:
       "A notebook-first AI cookbook. Jupyter notebook examples and tutorials.",
     site: siteWithBase,
-    items: notebooks.map((notebook) => ({
-      title: notebook.data.title,
-      pubDate: notebook.data.date
-        ? new Date(notebook.data.date)
-        : new Date(),
-      description: notebook.data.description || "",
-      // Absolute URL for NLWeb compatibility (used as document identifier)
-      link: new URL(withBase(`/notebook/${notebook.data.slug}/`), siteUrl).href,
-      categories: notebook.data.tags || [],
-      author: notebook.data.authors.map((a) => a.github).join(", "),
-    })),
+    xmlns: {
+      atom: "http://www.w3.org/2005/Atom",
+    },
+    items: sorted.map((notebook) => {
+      // Resolve author display names from authors.yaml
+      const authorNames = notebook.data.authors
+        .map((a) => authorsCache[a.github]?.name ?? a.github)
+        .join(", ");
+
+      return {
+        title: notebook.data.title,
+        // Only include pubDate when the entry has an explicit date
+        ...(notebook.data.date
+          ? { pubDate: new Date(notebook.data.date) }
+          : {}),
+        description: notebook.data.description || "",
+        // Absolute URL for NLWeb compatibility (used as document identifier)
+        link: new URL(withBase(`/notebook/${notebook.data.slug}/`), siteUrl)
+          .href,
+        categories: notebook.data.tags || [],
+        author: authorNames,
+      };
+    }),
     customData: `<language>en-us</language>
+<lastBuildDate>${lastBuildDate}</lastBuildDate>
+<atom:link href="${feedUrl}" rel="self" type="application/rss+xml"/>
 <docs>${REPO_URL}</docs>`,
     stylesheet: withBase("/rss/styles.xsl"),
   });


### PR DESCRIPTION
## Enhance RSS feed metadata and browser preview

### Changes

**`site/src/pages/rss.xml.ts`**
- Resolve author display names from `authors.yaml` instead of raw GitHub usernames
- Sort entries by date descending (newest first)
- Add `atom:link rel="self"` for RSS spec compliance
- Add `<lastBuildDate>` derived from the most recent entry date
- Omit `pubDate` for entries without an explicit date instead of using build time as a fallback
- Declare `atom` XML namespace

**`site/public/rss/styles.xsl`**
- Show description text below each entry title
- Show author names with "By" prefix
- Display category tags as styled pill badges
- Handle missing fields gracefully (conditional rendering)

### Why

The RSS feed XML had all the right metadata, but the browser preview (XSL stylesheet) only displayed title and publish date. Newsreaders already saw the full data — this brings the human-readable preview up to parity. The feed itself also gains spec-compliant elements (`atom:link`, `lastBuildDate`) and resolves author names for better readability.
