### PR TITLE
Add Mastering Foundry IQ recipe

### DIFF
--- a/authors.yaml
+++ b/authors.yaml
@@ -28,6 +28,12 @@ anihitk07:
   githubUrl: "https://github.com/anihitk07"
   linkedinUrl: "https://www.linkedin.com/in/anirban-ganguly-uk/"
 
+farzad528:
+  name: "Farzad Sunavala"
+  title: "Principal Product Manager"
+  avatar: "https://github.com/farzad528.png?size=200"
+  githubUrl: "https://github.com/farzad528"
+
 # Test authors for development
 jane-doe:
   name: "Jane Doe"

--- a/notebooks/mastering-foundry-iq.ipynb
+++ b/notebooks/mastering-foundry-iq.ipynb
@@ -1,0 +1,2528 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d111e8eb",
+   "metadata": {},
+   "source": [
+    "Build 2026 ships **Foundry IQ**, Microsoft's intelligence layer for agentic\n",
+    "retrieval. A Foundry IQ *Knowledge Base* (KB) wraps one or more\n",
+    "*Knowledge Sources* (KS) with an LLM that **plans subqueries**, executes\n",
+    "them in parallel, **reranks** the results, and **synthesizes** a cited\n",
+    "answer.\n",
+    "\n",
+    "This notebook is the canonical recipe for the full surface. It walks you\n",
+    "through every Knowledge Source supported on the\n",
+    "**`2026-05-01-preview`** API surface (the one backing the upcoming Build\n",
+    "2026 release), assembles **one** KB that fans out to all of them, and\n",
+    "plugs that KB into both a **Foundry Agent** (hero scenario) and a\n",
+    "**Microsoft Agent Framework** agent.\n",
+    "\n",
+    "## Learning goals\n",
+    "\n",
+    "By the end you will:\n",
+    "\n",
+    "1. Provision a Search index with vector + semantic configuration and load it\n",
+    "2. Create one Knowledge Source per supported type — Search Index, Azure\n",
+    "   Blob, **File**, Indexed OneLake, Indexed SharePoint, Remote SharePoint,\n",
+    "   **Indexed SQL**, Web, **Fabric Data Agent**, **Fabric Ontology**,\n",
+    "   **WorkIQ**, and **MCP Server**\n",
+    "3. Assemble **one** Knowledge Base that references every KS you configured\n",
+    "4. Run a complex multi-part query and inspect the planner's activity trace\n",
+    "5. Continue the conversation multi-turn\n",
+    "6. Talk to the KB directly over MCP (`tools/list` + `tools/call`)\n",
+    "7. Wire the KB into a **Foundry Agent** (hero) — `RemoteTool` project\n",
+    "   connection + agent + conversation + Responses API\n",
+    "8. Wire the same KB into a **Microsoft Agent Framework** agent via\n",
+    "   `MCPStreamableHTTPTool`\n",
+    "9. Tear every resource down\n",
+    "\n",
+    "## Architecture\n",
+    "\n",
+    "```text\n",
+    "            ┌───────────────────────────────────────────────────────────┐\n",
+    "            │                    Foundry IQ Pipeline                    │\n",
+    "            └───────────────────────────────────────────────────────────┘\n",
+    "   query ─► Knowledge Base ─► LLM planner ─► parallel subqueries ─┐\n",
+    "              │                                                    │\n",
+    "              │                                                    ▼\n",
+    "              │                          ┌──────── Knowledge Sources ────────┐\n",
+    "              │                          │ Search Index │ Blob │ File │ SQL │\n",
+    "              │                          │ OneLake │ SharePoint (Indexed +  │\n",
+    "              │                          │ Remote) │ Web │ Fabric DA/Ont │  │\n",
+    "              │                          │ WorkIQ │ MCP Server             │\n",
+    "              │                          └────────────────────────────────────┘\n",
+    "              ▼                                                    │\n",
+    "        Answer synthesis ◄── reranked, deduped results ◄──────────┘\n",
+    "              │\n",
+    "              ▼\n",
+    "          Cited answer + activity trace\n",
+    "```\n",
+    "\n",
+    "Every section that creates a Knowledge Source is **independently skippable**.\n",
+    "Set its env vars to enable, leave them blank to skip cleanly — the KB at the\n",
+    "bottom is assembled from whichever KS were created in this run.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6caefd57",
+   "metadata": {},
+   "source": [
+    "## 1 - Prerequisites\n",
+    "\n",
+    "| | |\n",
+    "|---|---|\n",
+    "| Azure AI Search service | In a [Build 2026 preview region](https://learn.microsoft.com/azure/search/search-region-support) |\n",
+    "| Microsoft Foundry project | One chat deployment (e.g. `gpt-4.1-mini`, `gpt-5-mini`, `gpt-4o`) + one embedding deployment (e.g. `text-embedding-3-large`, `text-embedding-ada-002`) |\n",
+    "\n",
+    "Each Knowledge Source section below lists its own resource prerequisites. **None of them are required** to run this notebook end-to-end - any section whose env vars are blank is skipped cleanly.\n",
+    "\n",
+    "### Configure your environment\n",
+    "\n",
+    "Set the variables below in your shell, or drop them into a local `.env` file next to this notebook (the repo's `.gitignore` already excludes `.env`).\n",
+    "\n",
+    "**Required:**\n",
+    "\n",
+    "```bash\n",
+    "SEARCH_ENDPOINT=https://<your-search-service>.search.windows.net\n",
+    "SEARCH_API_KEY=<your-search-admin-key>\n",
+    "AOAI_ENDPOINT=https://<your-foundry-resource>.openai.azure.com\n",
+    "AOAI_API_KEY=<your-azure-openai-key>\n",
+    "AOAI_GPT_DEPLOYMENT=gpt-4.1-mini          # or gpt-5-mini, gpt-4o, ...\n",
+    "AOAI_EMBEDDING_DEPLOYMENT=text-embedding-3-large\n",
+    "```\n",
+    "\n",
+    "**Optional** (each unlocks one Knowledge Source - leave blank to skip): `FOUNDRY_PROJECT_ENDPOINT`, `FOUNDRY_PROJECT_RESOURCE_ID`, `BB26_STORAGE_RID`, `BB26_BLOB_CONTAINER`, `BB26_FILE_UPLOAD_PATH`, `BB26_ONELAKE_*`, `BB26_FABRIC_*`, `BB26_SQL_*`, `BB26_SP_*`, `BB26_MCP_SERVER_*`, `BB26_WORKIQ_USER_TOKEN`. See the per-section prereq tables below for exact names.\n",
+    "\n",
+    "### Install dependencies\n",
+    "\n",
+    "Foundry IQ ships on the `2026-05-01-preview` Search API which is only exposed by the **alpha** `azure-search-documents` SDK from the [Azure SDK public feed](https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/). The next cell installs the pinned dependencies in-place; you do not need a separate `requirements.txt`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4ae18d81",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "# Foundry IQ requires the alpha azure-search-documents SDK that exposes the\n",
+    "# 2026-05-01-preview KnowledgeBase / KnowledgeSource surface. If a 12.1.0a*\n",
+    "# build is already installed (e.g. from a previous run) this cell is a fast\n",
+    "# no-op. The --extra-index-url points at the Azure SDK public preview feed.\n",
+    "import importlib.metadata as _md\n",
+    "try:\n",
+    "    _v = _md.version(\"azure-search-documents\")\n",
+    "    _ok = _v.startswith(\"12.1.0a\")\n",
+    "except _md.PackageNotFoundError:\n",
+    "    _ok = False\n",
+    "if not _ok:\n",
+    "    %pip install --quiet \\\n",
+    "        \"azure-search-documents==12.1.0a20260526002\" \\\n",
+    "        \"azure-identity>=1.19.0\" \\\n",
+    "        \"azure-core>=1.32.0\" \\\n",
+    "        \"python-dotenv>=1.0.1\" \\\n",
+    "        \"requests>=2.32.3\" \\\n",
+    "        \"httpx>=0.28.1\" \\\n",
+    "        \"agent-framework>=0.1.0\" \\\n",
+    "        \"agent-framework-openai>=0.1.0\" \\\n",
+    "        --extra-index-url https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2898c400",
+   "metadata": {},
+   "source": [
+    "## 2 · Configure clients + helpers\n",
+    "\n",
+    "One `SearchIndexClient` + one `DefaultAzureCredential` for Foundry/ARM is\n",
+    "reused throughout. We also define:\n",
+    "\n",
+    "- `env(name, required=False)` — env-var lookup with a friendly error\n",
+    "- `azure_openai_resource_uri()` — trims `/openai/...` paths\n",
+    "- `ks_status(name)` — `GET /knowledgesources(name)/status`, used after\n",
+    "  every create to confirm the KS isn't stuck on `creating`\n",
+    "- `created_ks` — a list that every KS section appends to on success; the\n",
+    "  single Knowledge Base in §15 reads from it\n",
+    "- `created_resources` — a dict the cleanup section walks in dependency\n",
+    "  order\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "01f09c12",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Search service       : https://<your-search-service>.search.windows.net\n",
+      "Foundry / AOAI       : https://<your-foundry-resource>.openai.azure.com\n",
+      "Chat deployment      : gpt-4.1-mini (gpt-4.1-mini)\n",
+      "Embedding deployment : text-embedding-ada-002 (text-embedding-ada-002, 1536 dims)\n",
+      "API version          : 2026-05-01-preview\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "from typing import Optional\n",
+    "\n",
+    "from azure.core.credentials import AzureKeyCredential\n",
+    "from azure.search.documents.indexes import SearchIndexClient\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv(override=True)\n",
+    "\n",
+    "\n",
+    "def env(name: str, *, required: bool = True, default: Optional[str] = None) -> Optional[str]:\n",
+    "    value = os.getenv(name, default)\n",
+    "    if required and not value:\n",
+    "        raise RuntimeError(f\"Missing required env var: {name}\")\n",
+    "    return value or None\n",
+    "\n",
+    "\n",
+    "def azure_openai_resource_uri(endpoint: str) -> str:\n",
+    "    return endpoint.split(\"/openai/\", 1)[0].rstrip(\"/\")\n",
+    "\n",
+    "\n",
+    "# ---- Required ------------------------------------------------------------\n",
+    "SEARCH_ENDPOINT = env(\"SEARCH_ENDPOINT\")\n",
+    "SEARCH_API_KEY = env(\"SEARCH_API_KEY\")\n",
+    "AOAI_ENDPOINT = azure_openai_resource_uri(env(\"AOAI_ENDPOINT\"))\n",
+    "AOAI_API_KEY = env(\"AOAI_API_KEY\")\n",
+    "\n",
+    "GPT_DEPLOYMENT = env(\"AOAI_GPT_DEPLOYMENT\", required=False, default=\"gpt-4.1-mini\")\n",
+    "GPT_MODEL = env(\"AOAI_GPT_MODEL\", required=False, default=GPT_DEPLOYMENT)\n",
+    "EMBEDDING_DEPLOYMENT = env(\"AOAI_EMBEDDING_DEPLOYMENT\", required=False, default=\"text-embedding-3-large\")\n",
+    "EMBEDDING_MODEL = env(\"AOAI_EMBEDDING_MODEL\", required=False, default=EMBEDDING_DEPLOYMENT)\n",
+    "EMBEDDING_DIMENSIONS = int(env(\"AOAI_EMBEDDING_DIMENSIONS\", required=False, default=\"3072\"))\n",
+    "\n",
+    "# ---- API + resource names -----------------------------------------------\n",
+    "API_VERSION = \"2026-05-01-preview\"\n",
+    "INDEX_NAME = \"mfiq-earth-at-night\"\n",
+    "KB_NAME = \"mfiq-master-kb\"\n",
+    "\n",
+    "credential = AzureKeyCredential(SEARCH_API_KEY)\n",
+    "index_client = SearchIndexClient(endpoint=SEARCH_ENDPOINT, credential=credential)\n",
+    "\n",
+    "# ---- Trackers consumed by §15 (KB) and §22 (cleanup) --------------------\n",
+    "created_ks: list[str] = []\n",
+    "created_resources: dict[str, str] = {}\n",
+    "\n",
+    "print(f\"Search service       : {SEARCH_ENDPOINT}\")\n",
+    "print(f\"Foundry / AOAI       : {AOAI_ENDPOINT}\")\n",
+    "print(f\"Chat deployment      : {GPT_DEPLOYMENT} ({GPT_MODEL})\")\n",
+    "print(f\"Embedding deployment : {EMBEDDING_DEPLOYMENT} ({EMBEDDING_MODEL}, {EMBEDDING_DIMENSIONS} dims)\")\n",
+    "print(f\"API version          : {API_VERSION}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "583a02fc",
+   "metadata": {},
+   "source": [
+    "A handful of REST helpers — most Build 2026 Knowledge Source kinds are\n",
+    "not yet wrapped by the alpha SDK, so we hit `/knowledgesources(...)` over\n",
+    "`requests` directly. The bodies mirror the validated `.http` templates in\n",
+    "`../build2026/templates/`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "78a60723",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import requests\n",
+    "\n",
+    "SEARCH_HEADERS = {\n",
+    "    \"api-key\": SEARCH_API_KEY,\n",
+    "    \"Content-Type\": \"application/json\",\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def ks_url(name: str) -> str:\n",
+    "    return f\"{SEARCH_ENDPOINT}/knowledgesources('{name}')?api-version={API_VERSION}\"\n",
+    "\n",
+    "\n",
+    "def kb_url(name: str) -> str:\n",
+    "    return f\"{SEARCH_ENDPOINT}/knowledgebases('{name}')?api-version={API_VERSION}\"\n",
+    "\n",
+    "\n",
+    "def put_ks(name: str, body: dict) -> dict:\n",
+    "    \"\"\"PUT a Knowledge Source and return the representation.\"\"\"\n",
+    "    headers = {**SEARCH_HEADERS, \"Prefer\": \"return=representation\"}\n",
+    "    r = requests.put(ks_url(name), headers=headers, json=body, timeout=120)\n",
+    "    if r.status_code >= 300:\n",
+    "        raise RuntimeError(f\"PUT KS {name} failed: HTTP {r.status_code} -- {r.text[:600]}\")\n",
+    "    return r.json()\n",
+    "\n",
+    "\n",
+    "def get_ks_status(name: str) -> dict:\n",
+    "    url = f\"{SEARCH_ENDPOINT}/knowledgesources('{name}')/status?api-version={API_VERSION}\"\n",
+    "    r = requests.get(url, headers=SEARCH_HEADERS, timeout=60)\n",
+    "    r.raise_for_status()\n",
+    "    return r.json()\n",
+    "\n",
+    "\n",
+    "def summarize_ks(name: str) -> None:\n",
+    "    try:\n",
+    "        status = get_ks_status(name)\n",
+    "    except Exception as exc:\n",
+    "        print(f\"  status: <unavailable: {exc.__class__.__name__}>\")\n",
+    "        return\n",
+    "    sync = status.get(\"synchronizationStatus\", \"?\")\n",
+    "    last = (status.get(\"lastSynchronizationState\") or {}).get(\"status\", \"n/a\")\n",
+    "    stats = status.get(\"statistics\") or {}\n",
+    "    print(f\"  synchronizationStatus={sync}  lastSync={last}  stats={stats}\")\n",
+    "\n",
+    "\n",
+    "def skip(section: str, reason: str) -> None:\n",
+    "    print(f\"[skipped] {section}: {reason}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4dd53bc0",
+   "metadata": {},
+   "source": [
+    "## 3 · Provision the backing Search index\n",
+    "\n",
+    "The **Search Index KS** in §4 needs an existing index to point at. We\n",
+    "declare a tiny but production-shaped index with three configurations:\n",
+    "\n",
+    "- A **vector field** sized for whatever embedding model you configured (1536\n",
+    "  for `text-embedding-ada-002`, 3072 for `text-embedding-3-large`).\n",
+    "- An **HNSW** vector profile plus an `AzureOpenAIVectorizer` so the service\n",
+    "  embeds query strings on the fly — you never have to embed at query time.\n",
+    "- A **semantic configuration** — required for agentic retrieval; the KB's\n",
+    "  planner uses the semantic ranker to rerank candidates before synthesis.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "bd5b1444",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Index 'mfiq-earth-at-night' is ready (1536-dim vector field).\n"
+     ]
+    }
+   ],
+   "source": [
+    "from azure.search.documents.indexes.models import (\n",
+    "    AzureOpenAIVectorizer,\n",
+    "    AzureOpenAIVectorizerParameters,\n",
+    "    HnswAlgorithmConfiguration,\n",
+    "    SearchField,\n",
+    "    SearchFieldDataType,\n",
+    "    SearchIndex,\n",
+    "    SemanticConfiguration,\n",
+    "    SemanticField,\n",
+    "    SemanticPrioritizedFields,\n",
+    "    SemanticSearch,\n",
+    "    SimpleField,\n",
+    "    VectorSearch,\n",
+    "    VectorSearchProfile,\n",
+    ")\n",
+    "\n",
+    "fields = [\n",
+    "    SimpleField(name=\"id\", type=SearchFieldDataType.String, key=True, filterable=True, sortable=True, facetable=True),\n",
+    "    SearchField(name=\"page_chunk\", type=SearchFieldDataType.String),\n",
+    "    SearchField(\n",
+    "        name=\"page_embedding\",\n",
+    "        type=SearchFieldDataType.Collection(SearchFieldDataType.Single),\n",
+    "        vector_search_dimensions=EMBEDDING_DIMENSIONS,\n",
+    "        vector_search_profile_name=\"hnsw_profile\",\n",
+    "    ),\n",
+    "    SimpleField(name=\"page_number\", type=SearchFieldDataType.Int32, filterable=True, sortable=True, facetable=True),\n",
+    "]\n",
+    "\n",
+    "embedding_params = AzureOpenAIVectorizerParameters(\n",
+    "    resource_url=AOAI_ENDPOINT,\n",
+    "    deployment_name=EMBEDDING_DEPLOYMENT,\n",
+    "    api_key=AOAI_API_KEY,\n",
+    "    model_name=EMBEDDING_MODEL,\n",
+    ")\n",
+    "\n",
+    "vector_search = VectorSearch(\n",
+    "    profiles=[VectorSearchProfile(name=\"hnsw_profile\", algorithm_configuration_name=\"alg\", vectorizer_name=\"aoai_vec\")],\n",
+    "    algorithms=[HnswAlgorithmConfiguration(name=\"alg\")],\n",
+    "    vectorizers=[AzureOpenAIVectorizer(vectorizer_name=\"aoai_vec\", parameters=embedding_params)],\n",
+    ")\n",
+    "\n",
+    "semantic_search = SemanticSearch(\n",
+    "    default_configuration_name=\"semantic_config\",\n",
+    "    configurations=[\n",
+    "        SemanticConfiguration(\n",
+    "            name=\"semantic_config\",\n",
+    "            prioritized_fields=SemanticPrioritizedFields(content_fields=[SemanticField(field_name=\"page_chunk\")]),\n",
+    "        )\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "index_client.create_or_update_index(\n",
+    "    SearchIndex(\n",
+    "        name=INDEX_NAME,\n",
+    "        fields=fields,\n",
+    "        vector_search=vector_search,\n",
+    "        semantic_search=semantic_search,\n",
+    "    )\n",
+    ")\n",
+    "created_resources[\"index\"] = INDEX_NAME\n",
+    "print(f\"Index '{INDEX_NAME}' is ready ({EMBEDDING_DIMENSIONS}-dim vector field).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75cdbdb4",
+   "metadata": {},
+   "source": [
+    "Load the NASA *Earth at Night* dataset. Each row is a pre-chunked page\n",
+    "with an embedding already attached. If your embedding deployment is\n",
+    "`text-embedding-3-large` (3072 dims) the file works as-is; for any other\n",
+    "model we **re-embed** each chunk using the deployment configured in §2,\n",
+    "so the dimensions match what the index expects.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2629909d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Re-embedding 194 chunks with text-embedding-ada-002 (1536 dims)...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Uploaded 194 documents to 'mfiq-earth-at-night'.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from azure.search.documents import SearchIndexingBufferedSender\n",
+    "from openai import AzureOpenAI\n",
+    "\n",
+    "DATA_URL = (\n",
+    "    \"https://raw.githubusercontent.com/Azure-Samples/azure-search-sample-data\"\n",
+    "    \"/refs/heads/main/nasa-e-book/earth-at-night-json/documents.json\"\n",
+    ")\n",
+    "raw_docs = requests.get(DATA_URL, timeout=60).json()\n",
+    "\n",
+    "# Re-embed if the file's pre-computed 3072-dim vectors don't match this index.\n",
+    "needs_reembed = EMBEDDING_DIMENSIONS != 3072\n",
+    "if needs_reembed:\n",
+    "    print(f\"Re-embedding {len(raw_docs)} chunks with {EMBEDDING_DEPLOYMENT} ({EMBEDDING_DIMENSIONS} dims)...\")\n",
+    "    oai = AzureOpenAI(api_key=AOAI_API_KEY, azure_endpoint=AOAI_ENDPOINT, api_version=\"2024-10-21\")\n",
+    "    # Batch in groups of 16 to avoid token-rate spikes.\n",
+    "    batch_size = 16\n",
+    "    for start in range(0, len(raw_docs), batch_size):\n",
+    "        batch = raw_docs[start : start + batch_size]\n",
+    "        resp = oai.embeddings.create(model=EMBEDDING_DEPLOYMENT, input=[d[\"page_chunk\"] for d in batch])\n",
+    "        for doc, item in zip(batch, resp.data):\n",
+    "            doc[\"page_embedding\"] = item.embedding\n",
+    "            doc.pop(\"page_embedding_text_3_large\", None)\n",
+    "else:\n",
+    "    for d in raw_docs:\n",
+    "        d[\"page_embedding\"] = d.pop(\"page_embedding_text_3_large\")\n",
+    "\n",
+    "with SearchIndexingBufferedSender(\n",
+    "    endpoint=SEARCH_ENDPOINT, index_name=INDEX_NAME, credential=credential\n",
+    ") as sender:\n",
+    "    sender.upload_documents(documents=raw_docs)\n",
+    "\n",
+    "print(f\"Uploaded {len(raw_docs)} documents to '{INDEX_NAME}'.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0dc18044",
+   "metadata": {},
+   "source": [
+    "## 4 · Search Index Knowledge Source\n",
+    "\n",
+    "| | |\n",
+    "|---|---|\n",
+    "| **`kind`** | `searchIndex` |\n",
+    "| **Auth model** | Same-service — Search admin api-key only. |\n",
+    "| **Pipeline** | None — points at an existing index. Most flexible; you keep full control of the schema, vectorizer, and skillset. |\n",
+    "| **Status** | Build 2026 preview (`2026-05-01-preview`) |\n",
+    "| **Env vars** | _(none)_ |\n",
+    "\n",
+    "**Prereqs:** the index from §3 (already created above).\n",
+    "\n",
+    "**Known issues / gotchas:** `baseFilter` on the KS narrows the queryable subset for the KB; semantics differ from per-call `filterAddOn`. Use `alwaysQuerySource=true` at retrieve time to bypass the planner's relevance heuristic.\n",
+    "\n",
+    "[Docs](https://learn.microsoft.com/azure/search/agentic-knowledge-source-how-to-search-index)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "6a5e5ce1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created mfiq-ks-search-index\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  synchronizationStatus=active  lastSync=n/a  stats={}\n"
+     ]
+    }
+   ],
+   "source": [
+    "KS_SEARCH_INDEX = \"mfiq-ks-search-index\"\n",
+    "\n",
+    "body = {\n",
+    "    \"name\": KS_SEARCH_INDEX,\n",
+    "    \"kind\": \"searchIndex\",\n",
+    "    \"description\": \"Search Index KS over the NASA Earth at Night sample.\",\n",
+    "    \"searchIndexParameters\": {\n",
+    "        \"searchIndexName\": INDEX_NAME,\n",
+    "        \"semanticConfigurationName\": \"semantic_config\",\n",
+    "        \"sourceDataFields\": [\n",
+    "            {\"name\": \"id\"},\n",
+    "            {\"name\": \"page_chunk\"},\n",
+    "            {\"name\": \"page_number\"},\n",
+    "        ],\n",
+    "    },\n",
+    "}\n",
+    "put_ks(KS_SEARCH_INDEX, body)\n",
+    "created_ks.append(KS_SEARCH_INDEX)\n",
+    "print(f\"Created {KS_SEARCH_INDEX}\")\n",
+    "summarize_ks(KS_SEARCH_INDEX)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "782e6704",
+   "metadata": {},
+   "source": [
+    "## 5 · Azure Blob Knowledge Source\n",
+    "\n",
+    "| | |\n",
+    "|---|---|\n",
+    "| **`kind`** | `azureBlob` |\n",
+    "| **Auth model** | System-assigned Managed Identity on the Search service. Grant it `Storage Blob Data Reader` on the storage account. |\n",
+    "| **Pipeline** | Generates an indexer + skillset behind the scenes; ingestion may take 30-180 s for large containers. |\n",
+    "| **Status** | Build 2026 preview (`2026-05-01-preview`) |\n",
+    "| **Env vars** | `BB26_STORAGE_RID`, `BB26_BLOB_CONTAINER` |\n",
+    "\n",
+    "**Prereqs:** Azure Storage account, a container with at least one document, MI role grant.\n",
+    "\n",
+    "**Known issues / gotchas:** `connectionString` uses the `ResourceId=...;` form (NOT account keys). `contentExtractionMode: 'minimal'` is the recommended default — `enhanced` invokes Document Intelligence and changes per-chunk pricing.\n",
+    "\n",
+    "[Docs](https://learn.microsoft.com/azure/search/agentic-knowledge-source-how-to-blob)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "1a3aa4e9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created mfiq-ks-blob\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  synchronizationStatus=creating  lastSync=n/a  stats={}\n"
+     ]
+    }
+   ],
+   "source": [
+    "KS_BLOB = \"mfiq-ks-blob\"\n",
+    "\n",
+    "storage_rid = env(\"BB26_STORAGE_RID\", required=False)\n",
+    "container = env(\"BB26_BLOB_CONTAINER\", required=False)\n",
+    "\n",
+    "if not storage_rid or not container:\n",
+    "    skip(KS_BLOB, \"set BB26_STORAGE_RID and BB26_BLOB_CONTAINER to enable\")\n",
+    "else:\n",
+    "    body = {\n",
+    "        \"name\": KS_BLOB,\n",
+    "        \"kind\": \"azureBlob\",\n",
+    "        \"description\": \"Indexed Azure Blob knowledge source.\",\n",
+    "        \"azureBlobParameters\": {\n",
+    "            \"connectionString\": f\"ResourceId={storage_rid};\",\n",
+    "            \"containerName\": container,\n",
+    "            \"ingestionParameters\": {\n",
+    "                \"contentExtractionMode\": \"minimal\",\n",
+    "                \"embeddingModel\": {\n",
+    "                    \"kind\": \"azureOpenAI\",\n",
+    "                    \"azureOpenAIParameters\": {\n",
+    "                        \"resourceUri\": AOAI_ENDPOINT,\n",
+    "                        \"apiKey\": AOAI_API_KEY,\n",
+    "                        \"deploymentId\": EMBEDDING_DEPLOYMENT,\n",
+    "                        \"modelName\": EMBEDDING_MODEL,\n",
+    "                    },\n",
+    "                },\n",
+    "            },\n",
+    "        },\n",
+    "    }\n",
+    "    put_ks(KS_BLOB, body)\n",
+    "    created_ks.append(KS_BLOB)\n",
+    "    print(f\"Created {KS_BLOB}\")\n",
+    "    summarize_ks(KS_BLOB)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "564f7140",
+   "metadata": {},
+   "source": [
+    "## 6 · File Knowledge Source (Build 2026)\n",
+    "\n",
+    "| | |\n",
+    "|---|---|\n",
+    "| **`kind`** | `file` |\n",
+    "| **Auth model** | Search admin api-key. Files upload directly into the KS — no separate data source or storage account. |\n",
+    "| **Pipeline** | Per-file ingestion. Files are POSTed individually after KS create. |\n",
+    "| **Status** | Build 2026 preview (`2026-05-01-preview`) |\n",
+    "| **Env vars** | `BB26_FILE_UPLOAD_PATH` |\n",
+    "\n",
+    "**Prereqs:** any local file (PDF, DOCX, HTML, TXT, etc.).\n",
+    "\n",
+    "**Known issues / gotchas:** Upload uses the **non-OData** route `POST /knowledgesources/{name}/files` (no quotes/parens, no `('...')`) with `Content-Type: application/octet-stream`. The OData form is fronted by a JSON-only middleware that rejects binary bodies.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "67e032df",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created mfiq-ks-file\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  upload attempt 1 got 429 — backing off 2s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Uploaded Zava Corporate Presentation.pdf (6,333,387 bytes) in 2 attempt(s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  synchronizationStatus=active  lastSync=n/a  stats={}\n"
+     ]
+    }
+   ],
+   "source": [
+    "KS_FILE = \"mfiq-ks-file\"\n",
+    "\n",
+    "file_path_str = env(\"BB26_FILE_UPLOAD_PATH\", required=False)\n",
+    "file_path = Path(file_path_str).expanduser().resolve() if file_path_str else None\n",
+    "\n",
+    "if not file_path or not file_path.is_file():\n",
+    "    skip(KS_FILE, f\"set BB26_FILE_UPLOAD_PATH to an existing file (got: {file_path_str!r})\")\n",
+    "else:\n",
+    "    # 1) Create the KS\n",
+    "    body = {\n",
+    "        \"name\": KS_FILE,\n",
+    "        \"kind\": \"file\",\n",
+    "        \"description\": f\"File KS holding uploaded copies of {file_path.name}.\",\n",
+    "        \"fileParameters\": {\n",
+    "            \"ingestionParameters\": {\n",
+    "                \"contentExtractionMode\": \"minimal\",\n",
+    "                \"embeddingModel\": {\n",
+    "                    \"kind\": \"azureOpenAI\",\n",
+    "                    \"azureOpenAIParameters\": {\n",
+    "                        \"resourceUri\": AOAI_ENDPOINT,\n",
+    "                        \"apiKey\": AOAI_API_KEY,\n",
+    "                        \"deploymentId\": EMBEDDING_DEPLOYMENT,\n",
+    "                        \"modelName\": EMBEDDING_MODEL,\n",
+    "                    },\n",
+    "                },\n",
+    "            },\n",
+    "        },\n",
+    "    }\n",
+    "    put_ks(KS_FILE, body)\n",
+    "    print(f\"Created {KS_FILE}\")\n",
+    "\n",
+    "    # 2) Upload the file via the non-OData /files route\n",
+    "    upload_url = f\"{SEARCH_ENDPOINT}/knowledgesources/{KS_FILE}/files?api-version={API_VERSION}\"\n",
+    "    upload_headers = {\n",
+    "        \"api-key\": SEARCH_API_KEY,\n",
+    "        \"Content-Type\": \"application/octet-stream\",\n",
+    "        \"Content-Disposition\": f'attachment; filename=\"{file_path.name}\"',\n",
+    "    }\n",
+    "    # Retry with backoff — file upload triggers a synchronous embed pass,\n",
+    "    # which on shared embedding deployments can transiently 429.\n",
+    "    import time as _time\n",
+    "    max_attempts = 5\n",
+    "    for attempt in range(1, max_attempts + 1):\n",
+    "        with file_path.open(\"rb\") as fh:\n",
+    "            r = requests.post(upload_url, headers=upload_headers, data=fh.read(), timeout=300)\n",
+    "        if r.status_code < 300:\n",
+    "            break\n",
+    "        if r.status_code == 429 and attempt < max_attempts:\n",
+    "            wait = 2 ** attempt\n",
+    "            print(f\"  upload attempt {attempt} got 429 — backing off {wait}s\")\n",
+    "            _time.sleep(wait)\n",
+    "            continue\n",
+    "        raise RuntimeError(f\"File upload failed: HTTP {r.status_code} -- {r.text[:600]}\")\n",
+    "    print(f\"Uploaded {file_path.name} ({file_path.stat().st_size:,} bytes) in {attempt} attempt(s)\")\n",
+    "\n",
+    "    created_ks.append(KS_FILE)\n",
+    "    summarize_ks(KS_FILE)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ee1b661",
+   "metadata": {},
+   "source": [
+    "## 7 · Indexed OneLake Knowledge Source (Fabric)\n",
+    "\n",
+    "| | |\n",
+    "|---|---|\n",
+    "| **`kind`** | `indexedOneLake` |\n",
+    "| **Auth model** | System-assigned Managed Identity on the Search service. Grant the MI **Contributor** on the Fabric workspace. |\n",
+    "| **Pipeline** | Indexer + skillset over the OneLake `Files/` path you choose. |\n",
+    "| **Status** | Build 2026 preview (`2026-05-01-preview`) |\n",
+    "| **Env vars** | `BB26_ONELAKE_WORKSPACE_ID`, `BB26_ONELAKE_ID`, `BB26_ONELAKE_PATH` |\n",
+    "\n",
+    "**Prereqs:** Fabric workspace + lakehouse with files at the target path.\n",
+    "\n",
+    "**Known issues / gotchas:** Workspace MI role assignment can take 5-10 min to propagate. If the indexer log shows 401/403, wait and re-trigger.\n",
+    "\n",
+    "[Docs](https://learn.microsoft.com/azure/search/agentic-knowledge-source-how-to-onelake)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "4a0c48cf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created mfiq-ks-onelake\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  synchronizationStatus=creating  lastSync=n/a  stats={}\n"
+     ]
+    }
+   ],
+   "source": [
+    "KS_ONELAKE = \"mfiq-ks-onelake\"\n",
+    "\n",
+    "workspace_id = env(\"BB26_ONELAKE_WORKSPACE_ID\", required=False)\n",
+    "lakehouse_id = env(\"BB26_ONELAKE_ID\", required=False)\n",
+    "target_path = env(\"BB26_ONELAKE_PATH\", required=False)\n",
+    "\n",
+    "if not (workspace_id and lakehouse_id and target_path):\n",
+    "    skip(KS_ONELAKE, \"set BB26_ONELAKE_WORKSPACE_ID, BB26_ONELAKE_ID, BB26_ONELAKE_PATH to enable\")\n",
+    "else:\n",
+    "    body = {\n",
+    "        \"name\": KS_ONELAKE,\n",
+    "        \"kind\": \"indexedOneLake\",\n",
+    "        \"description\": \"Indexed OneLake KS over a Fabric lakehouse folder.\",\n",
+    "        \"indexedOneLakeParameters\": {\n",
+    "            \"fabricWorkspaceId\": workspace_id,\n",
+    "            \"lakehouseId\": lakehouse_id,\n",
+    "            \"targetPath\": target_path,\n",
+    "            \"ingestionParameters\": {\n",
+    "                \"contentExtractionMode\": \"minimal\",\n",
+    "                \"disableImageVerbalization\": False,\n",
+    "                \"ingestionPermissionOptions\": [],\n",
+    "                \"embeddingModel\": {\n",
+    "                    \"kind\": \"azureOpenAI\",\n",
+    "                    \"azureOpenAIParameters\": {\n",
+    "                        \"resourceUri\": AOAI_ENDPOINT,\n",
+    "                        \"apiKey\": AOAI_API_KEY,\n",
+    "                        \"deploymentId\": EMBEDDING_DEPLOYMENT,\n",
+    "                        \"modelName\": EMBEDDING_MODEL,\n",
+    "                    },\n",
+    "                },\n",
+    "            },\n",
+    "        },\n",
+    "    }\n",
+    "    put_ks(KS_ONELAKE, body)\n",
+    "    created_ks.append(KS_ONELAKE)\n",
+    "    print(f\"Created {KS_ONELAKE}\")\n",
+    "    summarize_ks(KS_ONELAKE)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40203d72",
+   "metadata": {},
+   "source": [
+    "        ## 8 · Indexed SharePoint Knowledge Source\n",
+    "\n",
+    "        | | |\n",
+    "        |---|---|\n",
+    "        | **`kind`** | `indexedSharePoint` |\n",
+    "        | **Auth model** | App-only auth — Entra app with `Sites.Selected`. Connection string carries the app id + secret + tenant id. |\n",
+    "        | **Pipeline** | Indexer + skillset over an SP document library. |\n",
+    "        | **Status** | Build 2026 preview (`2026-05-01-preview`) |\n",
+    "        | **Env vars** | `BB26_SP_TENANT_ID`, `BB26_SP_SITE_URL`, `BB26_SP_LIBRARY_NAME`, `BB26_SP_CLIENT_ID`, `BB26_SP_CLIENT_SECRET` |\n",
+    "\n",
+    "        **Prereqs:** SP site, an Entra app with **Sites.Selected** granted on the site (admin consent required), and a client secret.\n",
+    "\n",
+    "```bash\n",
+    "az ad sp create-for-rbac --name mfiq-sp-indexer --skip-assignment\n",
+    "# Then in PowerShell:\n",
+    "# Grant-PnPAzureADAppSitePermission -AppId <id> -Site <site-url> -Permissions Read\n",
+    "```\n",
+    "\n",
+    "\n",
+    "        **Known issues / gotchas:** The connection string format is `SharePointOnlineEndpoint=...;ApplicationId=...;ApplicationSecret=...;TenantId=...`. Do NOT use account-key style strings.\n",
+    "\n",
+    "        [Docs](https://learn.microsoft.com/azure/search/agentic-knowledge-source-how-to-sharepoint-indexed)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ace576c8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created mfiq-ks-sp-indexed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  synchronizationStatus=creating  lastSync=n/a  stats={}\n"
+     ]
+    }
+   ],
+   "source": [
+    "KS_SP_INDEXED = \"mfiq-ks-sp-indexed\"\n",
+    "\n",
+    "sp_tenant = env(\"BB26_SP_TENANT_ID\", required=False)\n",
+    "sp_site = env(\"BB26_SP_SITE_URL\", required=False)\n",
+    "sp_library = env(\"BB26_SP_LIBRARY_NAME\", required=False)\n",
+    "sp_app_id = env(\"BB26_SP_CLIENT_ID\", required=False)\n",
+    "sp_app_secret = env(\"BB26_SP_CLIENT_SECRET\", required=False)\n",
+    "\n",
+    "if not all([sp_tenant, sp_site, sp_library, sp_app_id, sp_app_secret]):\n",
+    "    skip(KS_SP_INDEXED, \"set BB26_SP_* to enable\")\n",
+    "else:\n",
+    "    connection_string = (\n",
+    "        f\"SharePointOnlineEndpoint={sp_site};\"\n",
+    "        f\"ApplicationId={sp_app_id};\"\n",
+    "        f\"ApplicationSecret={sp_app_secret};\"\n",
+    "        f\"TenantId={sp_tenant}\"\n",
+    "    )\n",
+    "    body = {\n",
+    "        \"name\": KS_SP_INDEXED,\n",
+    "        \"kind\": \"indexedSharePoint\",\n",
+    "        \"description\": \"Indexed SharePoint KS over a site document library.\",\n",
+    "        \"indexedSharePointParameters\": {\n",
+    "            \"connectionString\": connection_string,\n",
+    "            \"containerName\": sp_library,\n",
+    "            \"query\": None,\n",
+    "            \"ingestionParameters\": {\n",
+    "                \"contentExtractionMode\": \"minimal\",\n",
+    "                \"disableImageVerbalization\": False,\n",
+    "                \"ingestionPermissionOptions\": [],\n",
+    "                \"embeddingModel\": {\n",
+    "                    \"kind\": \"azureOpenAI\",\n",
+    "                    \"azureOpenAIParameters\": {\n",
+    "                        \"resourceUri\": AOAI_ENDPOINT,\n",
+    "                        \"apiKey\": AOAI_API_KEY,\n",
+    "                        \"deploymentId\": EMBEDDING_DEPLOYMENT,\n",
+    "                        \"modelName\": EMBEDDING_MODEL,\n",
+    "                    },\n",
+    "                },\n",
+    "            },\n",
+    "        },\n",
+    "    }\n",
+    "    put_ks(KS_SP_INDEXED, body)\n",
+    "    created_ks.append(KS_SP_INDEXED)\n",
+    "    print(f\"Created {KS_SP_INDEXED}\")\n",
+    "    summarize_ks(KS_SP_INDEXED)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9021731",
+   "metadata": {},
+   "source": [
+    "## 9 · Remote SharePoint Knowledge Source (federated)\n",
+    "\n",
+    "| | |\n",
+    "|---|---|\n",
+    "| **`kind`** | `remoteSharePoint` |\n",
+    "| **Auth model** | **Per-user OBO** — the *caller's* token is passed on every retrieve via `x-ms-query-source-authorization`. Nothing stored on the KS or the Foundry connection. |\n",
+    "| **Pipeline** | None — federated. Real-time query into SharePoint Graph API. |\n",
+    "| **Status** | Build 2026 preview (`2026-05-01-preview`) |\n",
+    "| **Env vars** | `BB26_SP_TENANT_ID (only to confirm tenant; no creds stored)` |\n",
+    "\n",
+    "**Prereqs:** at query time, a user OBO token scoped to `https://search.azure.com/.default` from the **72f** Microsoft tenant.\n",
+    "\n",
+    "**Known issues / gotchas:** The KS body itself has **no credentials** — auth happens at retrieve. In Foundry Agent definitions, headers apply to all invocations; for true per-user auth, route via the Azure OpenAI Responses API + `structured_inputs`.\n",
+    "\n",
+    "[Docs](https://learn.microsoft.com/azure/search/agentic-knowledge-source-how-to-sharepoint-remote)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "d6df435b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created mfiq-ks-sp-remote — remember: requires per-user OBO at retrieve time.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  synchronizationStatus=active  lastSync=n/a  stats={}\n"
+     ]
+    }
+   ],
+   "source": [
+    "KS_SP_REMOTE = \"mfiq-ks-sp-remote\"\n",
+    "\n",
+    "body = {\n",
+    "    \"name\": KS_SP_REMOTE,\n",
+    "    \"kind\": \"remoteSharePoint\",\n",
+    "    \"description\": \"Federated SharePoint KS — token passed at retrieve time.\",\n",
+    "    \"encryptionKey\": None,\n",
+    "    \"remoteSharePointParameters\": {\n",
+    "        \"filterExpression\": \"filetype:docx OR filetype:pdf OR filetype:pptx\",\n",
+    "        \"resourceMetadata\": [\"Author\", \"Title\", \"LastModifiedDateTime\"],\n",
+    "        \"containerTypeId\": None,\n",
+    "    },\n",
+    "}\n",
+    "try:\n",
+    "    put_ks(KS_SP_REMOTE, body)\n",
+    "    created_ks.append(KS_SP_REMOTE)\n",
+    "    print(f\"Created {KS_SP_REMOTE} — remember: requires per-user OBO at retrieve time.\")\n",
+    "    summarize_ks(KS_SP_REMOTE)\n",
+    "except Exception as exc:\n",
+    "    # KS create itself is unauthenticated, so this usually only fails if SP federation\n",
+    "    # is disabled on the service. We don't block the rest of the notebook.\n",
+    "    skip(KS_SP_REMOTE, f\"create failed: {exc}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34cf5d41",
+   "metadata": {},
+   "source": [
+    "        ## 10 · Indexed SQL Knowledge Source (Build 2026)\n",
+    "\n",
+    "        | | |\n",
+    "        |---|---|\n",
+    "        | **`kind`** | `indexedSql` |\n",
+    "        | **Auth model** | System-assigned MI on the Search service. The MI must exist as a SQL **EXTERNAL PROVIDER user** with `db_datareader`. |\n",
+    "        | **Pipeline** | Indexer + skillset over a table/view. Change-tracking via a high-water-mark column. |\n",
+    "        | **Status** | Build 2026 preview (`2026-05-01-preview`) |\n",
+    "        | **Env vars** | `BB26_SQL_SUBSCRIPTION`, `BB26_SQL_RESOURCE_GROUP`, `BB26_SQL_SERVER`, `BB26_SQL_DATABASE`, `BB26_SQL_TABLE`, `BB26_SQL_HWM_COLUMN` |\n",
+    "\n",
+    "        **Prereqs:** Azure SQL DB, a table/view with a monotonically-increasing column for HWM. In the DB, as Entra admin:\n",
+    "\n",
+    "```sql\n",
+    "CREATE USER [<search-mi-name>] FROM EXTERNAL PROVIDER;\n",
+    "ALTER ROLE db_datareader ADD MEMBER [<search-mi-name>];\n",
+    "```\n",
+    "\n",
+    "\n",
+    "        **Known issues / gotchas:** `connectionString` uses the `Database=...;ResourceId=...;` shape with the FULL ARM ID of the SQL DB. Vary `contentColumns` and `embeddingColumns` to fit your schema.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "21f0247b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created mfiq-ks-sql\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  synchronizationStatus=creating  lastSync=n/a  stats={}\n"
+     ]
+    }
+   ],
+   "source": [
+    "KS_SQL = \"mfiq-ks-sql\"\n",
+    "from datetime import datetime, timezone\n",
+    "\n",
+    "sub = env(\"BB26_SQL_SUBSCRIPTION\", required=False)\n",
+    "rg = env(\"BB26_SQL_RESOURCE_GROUP\", required=False)\n",
+    "server = env(\"BB26_SQL_SERVER\", required=False)\n",
+    "db = env(\"BB26_SQL_DATABASE\", required=False)\n",
+    "table = env(\"BB26_SQL_TABLE\", required=False)\n",
+    "hwm = env(\"BB26_SQL_HWM_COLUMN\", required=False, default=\"UpdatedAt\")\n",
+    "\n",
+    "if not all([sub, rg, server, db, table]):\n",
+    "    skip(KS_SQL, \"set BB26_SQL_SUBSCRIPTION/RESOURCE_GROUP/SERVER/DATABASE/TABLE to enable\")\n",
+    "else:\n",
+    "    sql_db_rid = f\"/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Sql/servers/{server}/databases/{db}\"\n",
+    "    connection_string = f\"Database={db};ResourceId={sql_db_rid};Connection Timeout=30;\"\n",
+    "    body = {\n",
+    "        \"name\": KS_SQL,\n",
+    "        \"kind\": \"indexedSql\",\n",
+    "        \"description\": \"Indexed SQL KS over a documented knowledge-articles table.\",\n",
+    "        \"indexedSqlParameters\": {\n",
+    "            \"connectionString\": connection_string,\n",
+    "            \"tableOrView\": table,\n",
+    "            \"highWaterMarkColumnName\": hwm,\n",
+    "            \"contentColumns\": [\n",
+    "                {\"name\": \"title\", \"sourceField\": \"Title\", \"searchFieldType\": \"Edm.String\"},\n",
+    "                {\"name\": \"description\", \"sourceField\": \"Description\", \"searchFieldType\": \"Edm.String\"},\n",
+    "                {\"name\": \"category\", \"sourceField\": \"Category\", \"searchFieldType\": \"Edm.String\"},\n",
+    "                {\"name\": \"searchText\", \"sourceField\": \"SearchText\", \"searchFieldType\": \"Edm.String\"},\n",
+    "                {\"name\": \"updatedAt\", \"sourceField\": hwm, \"searchFieldType\": \"Edm.DateTimeOffset\"},\n",
+    "            ],\n",
+    "            \"embeddingColumns\": [{\"name\": \"contentEmbedding\", \"sourceField\": \"SearchText\"}],\n",
+    "            \"ingestionParameters\": {\n",
+    "                \"contentExtractionMode\": \"minimal\",\n",
+    "                \"embeddingModel\": {\n",
+    "                    \"kind\": \"azureOpenAI\",\n",
+    "                    \"azureOpenAIParameters\": {\n",
+    "                        \"resourceUri\": AOAI_ENDPOINT,\n",
+    "                        \"apiKey\": AOAI_API_KEY,\n",
+    "                        \"deploymentId\": EMBEDDING_DEPLOYMENT,\n",
+    "                        \"modelName\": EMBEDDING_MODEL,\n",
+    "                    },\n",
+    "                },\n",
+    "                \"ingestionSchedule\": {\n",
+    "                    \"interval\": \"P1D\",\n",
+    "                    \"startTime\": datetime.now(timezone.utc).strftime(\"%Y-%m-%dT%H:%M:%SZ\"),\n",
+    "                },\n",
+    "            },\n",
+    "        },\n",
+    "    }\n",
+    "    try:\n",
+    "        put_ks(KS_SQL, body)\n",
+    "        created_ks.append(KS_SQL)\n",
+    "        print(f\"Created {KS_SQL}\")\n",
+    "        summarize_ks(KS_SQL)\n",
+    "    except Exception as exc:\n",
+    "        skip(KS_SQL, f\"create failed (commonly an MI-on-SQL prereq issue): {exc}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7fb8762c",
+   "metadata": {},
+   "source": [
+    "## 11 · Web Knowledge Source\n",
+    "\n",
+    "| | |\n",
+    "|---|---|\n",
+    "| **`kind`** | `web` |\n",
+    "| **Auth model** | None — Foundry IQ brokers the search. No Bing key required from you. |\n",
+    "| **Pipeline** | Federated — real-time web search at every retrieve. |\n",
+    "| **Status** | Build 2026 preview (`2026-05-01-preview`) |\n",
+    "| **Env vars** | _(none)_ |\n",
+    "\n",
+    "**Prereqs:** none. Just decide which domains the planner is allowed to query and which are off-limits.\n",
+    "\n",
+    "**Known issues / gotchas:** `allowedDomains` is an allow-list — if you list any, only those are queried. `includeSubpages: true` is almost always what you want.\n",
+    "\n",
+    "[Docs](https://learn.microsoft.com/azure/search/agentic-knowledge-source-how-to-web)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "d9fec7a1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created mfiq-ks-web\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  synchronizationStatus=active  lastSync=n/a  stats={}\n"
+     ]
+    }
+   ],
+   "source": [
+    "KS_WEB = \"mfiq-ks-web\"\n",
+    "\n",
+    "body = {\n",
+    "    \"name\": KS_WEB,\n",
+    "    \"kind\": \"web\",\n",
+    "    \"description\": \"Web KS scoped to Microsoft Learn and Tech Community.\",\n",
+    "    \"webParameters\": {\n",
+    "        \"domains\": {\n",
+    "            \"allowedDomains\": [\n",
+    "                {\"address\": \"learn.microsoft.com\", \"includeSubpages\": True},\n",
+    "                {\"address\": \"techcommunity.microsoft.com\", \"includeSubpages\": True},\n",
+    "            ],\n",
+    "            \"blockedDomains\": [\n",
+    "                {\"address\": \"bing.com\", \"includeSubpages\": False},\n",
+    "            ],\n",
+    "        }\n",
+    "    },\n",
+    "}\n",
+    "put_ks(KS_WEB, body)\n",
+    "created_ks.append(KS_WEB)\n",
+    "print(f\"Created {KS_WEB}\")\n",
+    "summarize_ks(KS_WEB)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "517386e5",
+   "metadata": {},
+   "source": [
+    "## 12 · Fabric Data Agent Knowledge Source (Build 2026)\n",
+    "\n",
+    "| | |\n",
+    "|---|---|\n",
+    "| **`kind`** | `fabricDataAgent` |\n",
+    "| **Auth model** | System-assigned MI on the Search service. MI must be **Contributor** on the Fabric workspace hosting the Data Agent. |\n",
+    "| **Pipeline** | Federated — every retrieve invokes the published Fabric Data Agent. |\n",
+    "| **Status** | Build 2026 preview (`2026-05-01-preview`) |\n",
+    "| **Env vars** | `BB26_FABRIC_DATA_AGENT_WORKSPACE`, `BB26_FABRIC_DATA_AGENT_ID`, `BB26_FABRIC_DATA_AGENT_ENDPOINT` |\n",
+    "\n",
+    "**Prereqs:** a **published** Data Agent in Fabric, and the workspace + agent GUIDs.\n",
+    "\n",
+    "**Known issues / gotchas:** Fabric tokens are scoped to `https://api.fabric.microsoft.com/.default` — different from the AI Foundry scope. Workspace role propagation can take minutes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "7be9245e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created mfiq-ks-fabric-data-agent\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  synchronizationStatus=active  lastSync=n/a  stats={}\n"
+     ]
+    }
+   ],
+   "source": [
+    "KS_FABRIC_DA = \"mfiq-ks-fabric-data-agent\"\n",
+    "\n",
+    "fda_workspace = env(\"BB26_FABRIC_DATA_AGENT_WORKSPACE\", required=False)\n",
+    "fda_agent = env(\"BB26_FABRIC_DATA_AGENT_ID\", required=False)\n",
+    "fda_endpoint = env(\"BB26_FABRIC_DATA_AGENT_ENDPOINT\", required=False, default=\"https://msitapi.fabric.microsoft.com\")\n",
+    "\n",
+    "if not (fda_workspace and fda_agent):\n",
+    "    skip(KS_FABRIC_DA, \"set BB26_FABRIC_DATA_AGENT_WORKSPACE and _ID to enable\")\n",
+    "else:\n",
+    "    body = {\n",
+    "        \"name\": KS_FABRIC_DA,\n",
+    "        \"kind\": \"fabricDataAgent\",\n",
+    "        \"description\": \"Federated KS over a published Fabric Data Agent.\",\n",
+    "        \"fabricDataAgentParameters\": {\n",
+    "            \"fabricEndpoint\": fda_endpoint,\n",
+    "            \"workspaceId\": fda_workspace,\n",
+    "            \"dataAgentId\": fda_agent,\n",
+    "        },\n",
+    "    }\n",
+    "    try:\n",
+    "        put_ks(KS_FABRIC_DA, body)\n",
+    "        created_ks.append(KS_FABRIC_DA)\n",
+    "        print(f\"Created {KS_FABRIC_DA}\")\n",
+    "        summarize_ks(KS_FABRIC_DA)\n",
+    "    except Exception as exc:\n",
+    "        skip(KS_FABRIC_DA, f\"create failed: {exc}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "008cbfdb",
+   "metadata": {},
+   "source": [
+    "## 13 · Fabric Ontology Knowledge Source (Build 2026)\n",
+    "\n",
+    "| | |\n",
+    "|---|---|\n",
+    "| **`kind`** | `fabricOntology` |\n",
+    "| **Auth model** | Same MI pattern as Fabric Data Agent — workspace Contributor. |\n",
+    "| **Pipeline** | Federated — KB queries are translated into ontology / semantic-model queries. |\n",
+    "| **Status** | Build 2026 preview (`2026-05-01-preview`) |\n",
+    "| **Env vars** | `BB26_FABRIC_ONTOLOGY_WORKSPACE`, `BB26_FABRIC_ONTOLOGY_ID`, `BB26_FABRIC_ONTOLOGY_ENDPOINT` |\n",
+    "\n",
+    "**Prereqs:** a published Ontology in Fabric.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "06266ce1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created mfiq-ks-fabric-ontology\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  synchronizationStatus=active  lastSync=n/a  stats={}\n"
+     ]
+    }
+   ],
+   "source": [
+    "KS_FABRIC_ONT = \"mfiq-ks-fabric-ontology\"\n",
+    "\n",
+    "ont_workspace = env(\"BB26_FABRIC_ONTOLOGY_WORKSPACE\", required=False)\n",
+    "ont_id = env(\"BB26_FABRIC_ONTOLOGY_ID\", required=False)\n",
+    "ont_endpoint = env(\"BB26_FABRIC_ONTOLOGY_ENDPOINT\", required=False, default=\"https://msitapi.fabric.microsoft.com\")\n",
+    "\n",
+    "if not (ont_workspace and ont_id):\n",
+    "    skip(KS_FABRIC_ONT, \"set BB26_FABRIC_ONTOLOGY_WORKSPACE and _ID to enable\")\n",
+    "else:\n",
+    "    body = {\n",
+    "        \"name\": KS_FABRIC_ONT,\n",
+    "        \"kind\": \"fabricOntology\",\n",
+    "        \"description\": \"Federated KS over a Fabric ontology.\",\n",
+    "        \"fabricOntologyParameters\": {\n",
+    "            \"fabricEndpoint\": ont_endpoint,\n",
+    "            \"workspaceId\": ont_workspace,\n",
+    "            \"ontologyId\": ont_id,\n",
+    "        },\n",
+    "    }\n",
+    "    try:\n",
+    "        put_ks(KS_FABRIC_ONT, body)\n",
+    "        created_ks.append(KS_FABRIC_ONT)\n",
+    "        print(f\"Created {KS_FABRIC_ONT}\")\n",
+    "        summarize_ks(KS_FABRIC_ONT)\n",
+    "    except Exception as exc:\n",
+    "        skip(KS_FABRIC_ONT, f\"create failed: {exc}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb9e6933",
+   "metadata": {},
+   "source": [
+    "## 14 · WorkIQ Knowledge Source (Build 2026)\n",
+    "\n",
+    "| | |\n",
+    "|---|---|\n",
+    "| **`kind`** | `workIQ` |\n",
+    "| **Auth model** | **Per-user OBO**, just like Remote SharePoint. The caller's token (Microsoft `72f` tenant, scoped to `https://search.azure.com/.default`) is passed on every retrieve. |\n",
+    "| **Pipeline** | Federated — Microsoft 365 Graph search via the WorkIQ surface. |\n",
+    "| **Status** | Build 2026 preview (`2026-05-01-preview`) |\n",
+    "| **Env vars** | `BB26_WORKIQ_USER_TOKEN (only at retrieve time; KS create itself is unauthenticated)` |\n",
+    "\n",
+    "**Prereqs:** an account in the Microsoft `72f` tenant with WorkIQ entitlements.\n",
+    "\n",
+    "**Known issues / gotchas:** Set `maxRuntimeInSeconds: 180+` on the retrieve request — WorkIQ can be slow on first call as caches warm.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "84f2c520",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created mfiq-ks-workiq\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  synchronizationStatus=active  lastSync=n/a  stats={}\n"
+     ]
+    }
+   ],
+   "source": [
+    "KS_WORKIQ = \"mfiq-ks-workiq\"\n",
+    "\n",
+    "body = {\n",
+    "    \"name\": KS_WORKIQ,\n",
+    "    \"kind\": \"workIQ\",\n",
+    "    \"description\": \"Federated WorkIQ (M365 Graph) KS.\",\n",
+    "}\n",
+    "try:\n",
+    "    put_ks(KS_WORKIQ, body)\n",
+    "    created_ks.append(KS_WORKIQ)\n",
+    "    print(f\"Created {KS_WORKIQ}\")\n",
+    "    summarize_ks(KS_WORKIQ)\n",
+    "except Exception as exc:\n",
+    "    skip(KS_WORKIQ, f\"create failed: {exc}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14b69cd5",
+   "metadata": {},
+   "source": [
+    "## 15 · MCP Server Knowledge Source (Build 2026)\n",
+    "\n",
+    "| | |\n",
+    "|---|---|\n",
+    "| **`kind`** | `mcpServer` |\n",
+    "| **Auth model** | Either **none** (public MCP servers like Microsoft Learn) or via a **Foundry CustomKeys connection** (for servers that need an API key, e.g. Speedbird). |\n",
+    "| **Pipeline** | Federated — every retrieve does `tools/call` on the upstream MCP server. |\n",
+    "| **Status** | Build 2026 preview (`2026-05-01-preview`) |\n",
+    "| **Env vars** | `BB26_MCP_SERVER_URL (optional override)`, `BB26_MCP_SERVER_API_KEY (optional — only if your server requires a key)` |\n",
+    "\n",
+    "**Prereqs:** the upstream MCP server URL + tool names it publishes.\n",
+    "\n",
+    "**Known issues / gotchas:** `tools[].name` MUST match a tool the upstream server actually publishes. For `outputParsing.kind = 'auto'` Foundry IQ infers; use `'text'` or `'structured'` if auto fails.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "d24d9cc3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created mfiq-ks-mcp-learn (https://api.microsoft.ai/v3/mcp)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  synchronizationStatus=active  lastSync=n/a  stats={}\n"
+     ]
+    }
+   ],
+   "source": [
+    "KS_MCP = \"mfiq-ks-mcp-learn\"\n",
+    "\n",
+    "# Default to the always-public Microsoft Learn MCP server.\n",
+    "server_url = env(\"BB26_MCP_SERVER_URL\", required=False, default=\"https://learn.microsoft.com/api/mcp\")\n",
+    "learn_default = \"learn.microsoft.com\" in server_url\n",
+    "\n",
+    "body = {\n",
+    "    \"name\": KS_MCP,\n",
+    "    \"kind\": \"mcpServer\",\n",
+    "    \"description\": \"MCP Server KS — Microsoft Learn (no auth required).\",\n",
+    "    \"mcpServerParameters\": {\n",
+    "        \"serverURL\": server_url,\n",
+    "        \"tools\": [\n",
+    "            {\n",
+    "                \"name\": \"microsoft_docs_search\" if learn_default else \"web\",\n",
+    "                \"outputParsing\": {\"kind\": \"auto\"},\n",
+    "                \"inclusionMode\": \"reranked\",\n",
+    "                \"maxOutputTokens\": 4096,\n",
+    "            }\n",
+    "        ],\n",
+    "    },\n",
+    "}\n",
+    "# For servers that need an API key, the canonical pattern is a Foundry\n",
+    "# CustomKeys connection: see build2026/templates/foundryiq-mcp-server-ks.http\n",
+    "# for the PUT body. We skip that here to keep the notebook self-contained.\n",
+    "\n",
+    "try:\n",
+    "    put_ks(KS_MCP, body)\n",
+    "    created_ks.append(KS_MCP)\n",
+    "    print(f\"Created {KS_MCP} ({server_url})\")\n",
+    "    summarize_ks(KS_MCP)\n",
+    "except Exception as exc:\n",
+    "    skip(KS_MCP, f\"create failed: {exc}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d02aaa89",
+   "metadata": {},
+   "source": [
+    "## 16 · Sidebar: Purview ACL trim for indexed KS\n",
+    "\n",
+    "Indexed KS (Blob, OneLake, SharePoint Indexed, SQL) can optionally enforce\n",
+    "**document-level security** by snapshotting the source ACLs into Search and\n",
+    "requiring an `x-ms-query-source-authorization` header at retrieve time.\n",
+    "\n",
+    "Opt in by setting the KS's `ingestionParameters.ingestionPermissionOptions`\n",
+    "to e.g. `[\"userIds\", \"groupIds\"]`. Then at retrieve time, pass the user's\n",
+    "OBO token in the header — Search filters references down to what they're\n",
+    "allowed to see.\n",
+    "\n",
+    "Reference body: [`build2026/templates/foundryiq-purview-acl-integration.http`](../build2026/templates/foundryiq-purview-acl-integration.http).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0895e684",
+   "metadata": {},
+   "source": [
+    "## 17 · The Knowledge Base — one KB, three heterogeneous Knowledge Sources\n",
+    "\n",
+    "The KB is the singleton consumer of the KS layer. Sections 4–15 above\n",
+    "create up to twelve different KS so you can see the shape of each one;\n",
+    "this notebook then deliberately picks **three** of them to assemble a\n",
+    "**diverse but readable** demo KB:\n",
+    "\n",
+    "| KS in the demo KB | Why we picked it |\n",
+    "|---|---|\n",
+    "| `mfiq-ks-search-index` | The canonical KS — an existing Azure AI Search index you fully control. |\n",
+    "| `mfiq-ks-file` | Build 2026's direct-upload KS — no storage account, no indexer, no skillset. |\n",
+    "| `mfiq-ks-mcp-learn` | A federated MCP KS — every retrieve calls a live external MCP server (Microsoft Learn). |\n",
+    "\n",
+    "> Why only three? The preview cap is 10 KS per KB, but more importantly,\n",
+    "> three is enough to demonstrate **heterogeneity** (indexed vs. uploaded\n",
+    "> vs. federated). For your own KBs, mix any of the twelve types above —\n",
+    "> just keep the per-KB total under the current preview limit.\n",
+    "\n",
+    "The KB carries:\n",
+    "\n",
+    "| Setting | What it controls |\n",
+    "|---|---|\n",
+    "| `models` | Chat model used for query planning + answer synthesis |\n",
+    "| `knowledgeSources` | Which sources are in scope (we pass the curated three) |\n",
+    "| `retrievalReasoningEffort` | `minimal` / `low` / `medium` — how hard the planner thinks |\n",
+    "| `outputMode` | `extractiveData` (raw chunks) or `answerSynthesis` (cited NL answer) |\n",
+    "| `answerInstructions` | System prompt that shapes the synthesized answer |\n",
+    "\n",
+    "We pick **`answerSynthesis`** + **`low`** as the production-friendly default.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "80ab2ef1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Building KB 'mfiq-master-kb' referencing 3 knowledge source(s):\n",
+      "  - mfiq-ks-search-index\n",
+      "  - mfiq-ks-file\n",
+      "  - mfiq-ks-mcp-learn\n",
+      "\n",
+      "(The following KS were created but not added to this demo KB — they're available for your own KBs:)\n",
+      "  · mfiq-ks-blob\n",
+      "  · mfiq-ks-onelake\n",
+      "  · mfiq-ks-sp-indexed\n",
+      "  · mfiq-ks-sp-remote\n",
+      "  · mfiq-ks-sql\n",
+      "  · mfiq-ks-web\n",
+      "  · mfiq-ks-fabric-data-agent\n",
+      "  · mfiq-ks-fabric-ontology\n",
+      "  · mfiq-ks-workiq\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Knowledge Base 'mfiq-master-kb' is ready.\n"
+     ]
+    }
+   ],
+   "source": [
+    "if not created_ks:\n",
+    "    raise RuntimeError(\"No Knowledge Sources were created — cannot build a KB. Configure at least one KS env block.\")\n",
+    "\n",
+    "# For the demo KB we deliberately pick a SMALL, DIVERSE subset (max 10 KS per\n",
+    "# KB in current preview, but more importantly readability). Three is enough\n",
+    "# to show heterogeneity: one canonical index-backed source, one direct file\n",
+    "# upload source, and one federated MCP source.\n",
+    "HERO_KS = [\n",
+    "    \"mfiq-ks-search-index\",   # existing-index canonical\n",
+    "    \"mfiq-ks-file\",           # direct-upload (Build 2026)\n",
+    "    \"mfiq-ks-mcp-learn\",      # federated MCP (Microsoft Learn)\n",
+    "]\n",
+    "kb_sources = [n for n in HERO_KS if n in created_ks]\n",
+    "if not kb_sources:\n",
+    "    kb_sources = created_ks[:1]\n",
+    "\n",
+    "print(f\"Building KB '{KB_NAME}' referencing {len(kb_sources)} knowledge source(s):\")\n",
+    "for n in kb_sources:\n",
+    "    print(f\"  - {n}\")\n",
+    "skipped = [n for n in created_ks if n not in kb_sources]\n",
+    "if skipped:\n",
+    "    print(f\"\\n(The following KS were created but not added to this demo KB — they're available for your own KBs:)\")\n",
+    "    for n in skipped:\n",
+    "        print(f\"  · {n}\")\n",
+    "\n",
+    "kb_body = {\n",
+    "    \"name\": KB_NAME,\n",
+    "    \"description\": \"Master KB fanning out to a curated, heterogeneous mix of KS configured in this notebook run.\",\n",
+    "    \"outputMode\": \"answerSynthesis\",\n",
+    "    \"answerInstructions\": (\n",
+    "        \"Provide a concise, faithful answer using only the retrieved content. \"\n",
+    "        \"Preserve [ref_id:N] citations the planner returns.\"\n",
+    "    ),\n",
+    "    \"retrievalReasoningEffort\": {\"kind\": \"low\"},\n",
+    "    \"knowledgeSources\": [{\"name\": n} for n in kb_sources],\n",
+    "    \"models\": [\n",
+    "        {\n",
+    "            \"kind\": \"azureOpenAI\",\n",
+    "            \"azureOpenAIParameters\": {\n",
+    "                \"resourceUri\": AOAI_ENDPOINT,\n",
+    "                \"apiKey\": AOAI_API_KEY,\n",
+    "                \"deploymentId\": GPT_DEPLOYMENT,\n",
+    "                \"modelName\": GPT_MODEL,\n",
+    "            },\n",
+    "        }\n",
+    "    ],\n",
+    "}\n",
+    "r = requests.put(kb_url(KB_NAME), headers={**SEARCH_HEADERS, \"Prefer\": \"return=representation\"}, json=kb_body, timeout=60)\n",
+    "if r.status_code >= 300:\n",
+    "    raise RuntimeError(f\"PUT KB failed: HTTP {r.status_code} -- {r.text[:600]}\")\n",
+    "created_resources[\"kb\"] = KB_NAME\n",
+    "print(f\"\\nKnowledge Base '{KB_NAME}' is ready.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2228a163",
+   "metadata": {},
+   "source": [
+    "## 18 · Hero query — multi-source, multi-part question\n",
+    "\n",
+    "This is where agentic retrieval earns its keep. The query below bundles\n",
+    "**three different concerns** in one turn — exactly the case where naive\n",
+    "single-vector RAG falls apart, because no one source knows the answer.\n",
+    "\n",
+    "The KB will:\n",
+    "\n",
+    "1. **Plan** — the LLM decomposes the user turn into focused subqueries\n",
+    "2. **Retrieve** — each subquery is routed to the right KS in parallel\n",
+    "   (Earth-at-Night chunks for auroras, the uploaded Zava PDF for the\n",
+    "   corporate description, Microsoft Learn over MCP for agentic retrieval),\n",
+    "   and the semantic ranker reorders candidates\n",
+    "3. **Synthesize** — the LLM writes one grounded answer with `[ref_id:N]`\n",
+    "   citations that span all three sources\n",
+    "\n",
+    "`alwaysQuerySource=True` forces the planner to actually query each source\n",
+    "instead of short-circuiting. `includeActivity=True` exposes every step.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "7649a86d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ANSWER\n",
+      "------\n",
+      "The NASA Earth at Night dataset describes auroras primarily through detailed observational satellite imagery and astronaut photos. For example, the aurora australis over Antarctica is shown as bright, dynamic, swirling patterns in grayscale satellite images, with geographic context including coastlines and ocean labeled. The dataset highlights the visual phenomena as energetic particles dancing rapidly in the polar atmosphere, captured by special sensors on the Suomi NPP satellite. Another example is the aurora borealis over the Midwestern United States viewed from the ISS, showing a glowing green band above city lights, emphasizing the contrast between natural auroral light and artificial human-made illumination. The descriptions focus on the physical appearance, location, and natural light emissions, distinguishing auroral light in terms of color and spatial distribution against the dark nighttime Earth background [ref_id:1][ref_id:13][ref_id:19].\n",
+      "\n",
+      "In contrast, the Zava corporate presentation describes Zava's business as a manufacturer and distributor of advanced smart fiber materials with adaptive performance for various industries. It emphasizes innovation in smart fiber technology integrating nano sensors for applications across both B2B and B2C markets. The narrative highlights company growth since 2007, the development of cutting-edge products like the ThermoCore Baselayer and Auracore Fiber technology, and collaborations with industries including automotive, healthcare, aerospace, and sports. The description includes details about production and distribution facilities globally, organizational structure, product lines such as smart mesh apparel and cleats, and their mission focused on pioneering advanced materials. The presentation portrays the business through technological innovation, product development milestones, market reach, and corporate scale (over 10,000 employees) as of 2025 [ref_id:0][ref_id:9][ref_id:15].\n",
+      "\n",
+      "Separately, the Microsoft Learn documentation about agentic retrieval in Azure AI Search was not found in the retrieved content. No relevant information related to agentic retrieval or Azure AI Search from Microsoft Learn was present within the documents searched . \n",
+      "\n",
+      "In summary:\n",
+      "- NASA Earth at Night describes auroras as natural nighttime light phenomena captured by satellites and astronauts, focusing on their physical and spectral characteristics.\n",
+      "- Zava corporate presentation frames Zava's business as an advanced smart fiber technology company with product innovation, market expansion, and detailed operational structure.\n",
+      "- No content was retrieved about agentic retrieval in Azure AI Search from Microsoft Learn documentation.\n",
+      "\n",
+      "Activity steps : 7\n",
+      "References     : 22\n"
+     ]
+    }
+   ],
+   "source": [
+    "retrieve_url = f\"{SEARCH_ENDPOINT}/knowledgebases('{KB_NAME}')/retrieve?api-version={API_VERSION}\"\n",
+    "\n",
+    "# Per-KS retrieve parameter blocks. Only certain `kind`s expose tunables\n",
+    "# at retrieve time; the others use sensible defaults from the KB.\n",
+    "def ks_params_for(name: str) -> dict | None:\n",
+    "    if name == \"mfiq-ks-search-index\":\n",
+    "        return {\n",
+    "            \"kind\": \"searchIndex\",\n",
+    "            \"knowledgeSourceName\": name,\n",
+    "            \"includeReferences\": True,\n",
+    "            \"includeReferenceSourceData\": True,\n",
+    "            \"alwaysQuerySource\": True,\n",
+    "            \"maxOutputDocuments\": 50,\n",
+    "            \"failOnError\": False,\n",
+    "            \"rerankerThreshold\": 0.0,\n",
+    "        }\n",
+    "    if name == \"mfiq-ks-file\":\n",
+    "        return {\n",
+    "            \"kind\": \"file\",\n",
+    "            \"knowledgeSourceName\": name,\n",
+    "            \"includeReferences\": True,\n",
+    "            \"includeReferenceSourceData\": True,\n",
+    "            \"alwaysQuerySource\": True,\n",
+    "        }\n",
+    "    if name == \"mfiq-ks-mcp-learn\":\n",
+    "        return {\n",
+    "            \"kind\": \"mcpServer\",\n",
+    "            \"knowledgeSourceName\": name,\n",
+    "            \"includeReferences\": True,\n",
+    "        }\n",
+    "    return None\n",
+    "\n",
+    "\n",
+    "def retrieve(messages: list[dict], max_runtime_seconds: int = 180) -> dict:\n",
+    "    body = {\n",
+    "        \"messages\": [\n",
+    "            {\"role\": m[\"role\"], \"content\": [{\"type\": \"text\", \"text\": m[\"content\"]}]}\n",
+    "            for m in messages\n",
+    "        ],\n",
+    "        \"includeActivity\": True,\n",
+    "        \"maxRuntimeInSeconds\": max_runtime_seconds,\n",
+    "        \"knowledgeSourceParams\": [p for p in (ks_params_for(n) for n in kb_sources) if p],\n",
+    "    }\n",
+    "    r = requests.post(retrieve_url, headers=SEARCH_HEADERS, json=body, timeout=300)\n",
+    "    if r.status_code >= 300:\n",
+    "        raise RuntimeError(f\"Retrieve failed: HTTP {r.status_code} -- {r.text[:600]}\")\n",
+    "    return r.json()\n",
+    "\n",
+    "\n",
+    "def answer_text(result: dict) -> str:\n",
+    "    return \"\\n\\n\".join(\n",
+    "        c.get(\"text\", \"\")\n",
+    "        for message in (result.get(\"response\") or [])\n",
+    "        for c in (message.get(\"content\") or [])\n",
+    "        if c.get(\"type\") == \"text\"\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "messages = [\n",
+    "    {\n",
+    "        \"role\": \"user\",\n",
+    "        \"content\": (\n",
+    "            \"Compare how the NASA Earth at Night dataset describes auroras versus \"\n",
+    "            \"how the Zava corporate presentation describes Zava's business. \"\n",
+    "            \"Then, separately, what does the Microsoft Learn documentation say \"\n",
+    "            \"about agentic retrieval in Azure AI Search?\"\n",
+    "        ),\n",
+    "    }\n",
+    "]\n",
+    "result = retrieve(messages)\n",
+    "first_answer = answer_text(result)\n",
+    "\n",
+    "print(\"ANSWER\")\n",
+    "print(\"------\")\n",
+    "print(first_answer)\n",
+    "print()\n",
+    "print(f\"Activity steps : {len(result.get('activity') or [])}\")\n",
+    "print(f\"References     : {len(result.get('references') or [])}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd56cde0",
+   "metadata": {},
+   "source": [
+    "### 18b · Inspect the planner activity trace\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "6069c9a6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[\n",
+      "  {\n",
+      "    \"type\": \"mcpServer\",\n",
+      "    \"id\": 0,\n",
+      "    \"knowledgeSourceName\": \"mfiq-ks-mcp-learn\",\n",
+      "    \"queryTime\": \"2026-05-27T11:28:30.7685827Z\",\n",
+      "    \"count\": 0,\n",
+      "    \"error\": {\n",
+      "      \"code\": null,\n",
+      "      \"message\": \"MCP server 'https://api.microsoft.ai/v3/mcp' could not be reached while discovering tools. The MCP client tried multiple transport attempts and all of them failed:\\n  [1] Streamable HTTP (POST https://api.microsoft.ai/v3/mcp) -> 401 Unauthorized: {\\n  \\\"jsonrpc\\\": \\\"2.0\\\",\\n  \\\"id\\\": \\\"8f43a0b875aa02f69d53466fb3df4579\\\",\\n  \\\"error\\\": {\\n    \\\"code\\\": \\\"auth_missing_token\\\",\\n    \\\"message\\\": \\\"Authentication required. Please provide a valid bearer token. (Details: Authentication required)\\\",\\n    \\\"trace_id\\\": \\\"8f43a0b875aa02f69d53466fb3df4579\\\"\\n  }\\n}\\n  [2] SSE fallback (GET https://api.microsoft.ai/v3/mcp) -> 415 UnsupportedMediaType: {\\\"jsonrpc\\\":\\\"2.0\\\",\\\"id\\\":null,\\\"error\\\":{\\\"code\\\":\\\"request_unsupported_media_type\\\",\\\"message\\\":\\\"Content-Type not supported. (Details: Invalid content type. Expected application/json, got none)\\\",\\\"trace_id\\\":\\\"8f43a0b875aa02f69d53466fb3df4579\\\"}} To pass authentication headers from your request through to this MCP server, include them on the agent retrieval request as 'mfiq-ks-mcp-learn-header-name<N>' and 'mfiq-ks-mcp-learn-header-value<N>' (where '<N>' is an optional ordinal suffix, used to disambiguate multiple header pairs).\",\n",
+      "      \"target\": null,\n",
+      "      \"details\": [],\n",
+      "      \"additionalInfo\": []\n",
+      "    },\n",
+      "    \"mcpServerArguments\": {\n",
+      "      \"toolName\": \"web\",\n",
+      "      \"toolArguments\": {}\n",
+      "    }\n",
+      "  },\n",
+      "  {\n",
+      "    \"type\": \"modelQueryPlanning\",\n",
+      "    \"id\": 1,\n",
+      "    \"inputTokens\": 1289,\n",
+      "    \"outputTokens\": 94,\n",
+      "    \"modelName\": \"gpt-4.1-mini\",\n",
+      "    \"elapsedMs\": 1828\n",
+      "  },\n",
+      "  {\n",
+      "    \"type\": \"searchIndex\",\n",
+      "    \"id\": 2,\n",
+      "    \"knowledgeSourceName\": \"mfiq-ks-search-index\",\n",
+      "    \"queryTime\": \"2026-05-27T11:28:32.8446273Z\",\n",
+      "    \"count\": 50,\n",
+      "    \"elapsedMs\": 0,\n",
+      "    \"searchIndexArguments\": {\n",
+      "      \"search\": \"auroras NASA Earth at Night dataset\",\n",
+      "      \"filter\": null,\n",
+      "      \"semanticConfigurationName\": \"semantic_config\",\n",
+      "      \"sourceDataFields\": [\n",
+      "        {\n",
+      "          \"name\": \"page_chunk\"\n",
+      "        },\n",
+      "        {\n",
+      "          \"name\": \"id\"\n",
+      "        },\n",
+      "        {\n",
+      "          \"name\": \"page_number\"\n",
+      "        }\n",
+      "      ],\n",
+      "      \"searchFields\": []\n",
+      "    }\n",
+      "  },\n",
+      "  {\n",
+      "    \"type\": \"searchIndex\",\n",
+      "    \"id\": 3,\n",
+      "    \"knowledgeSourceName\": \"mfiq-ks-search-index\",\n",
+      "    \"queryTime\": \"2026-05-27T11:28:33.5587617Z\",\n",
+      "    \"count\": 50,\n",
+      "    \"elapsedMs\": 0,\n",
+      "    \"searchIndexArguments\": {\n",
+      "      \"search\": \"agentic retrieval Azure AI Search Microsoft Learn\",\n",
+      "      \"filter\": null,\n",
+      "      \"semanticConfigurationName\": \"semantic_config\",\n",
+      "      \"sourceDataFields\": [\n",
+      "        {\n",
+      "          \"name\": \"page_chunk\"\n",
+      "        },\n",
+      "        {\n",
+      "          \"name\": \"id\"\n",
+      "        },\n",
+      "        {\n",
+      "          \"name\": \"page_number\"\n",
+      "        }\n",
+      "      ],\n",
+      "      \"searchFields\": []\n",
+      "    }\n",
+      "  },\n",
+      "  {\n",
+      "    \"type\": \"file\",\n",
+      "    \"id\": 4,\n",
+      "    \"knowledgeSourceName\": \"mfiq-ks-file\",\n",
+      "    \"queryTime\": \"2026-05-27T11:28:34.9819302Z\",\n",
+      "    \"count\": 34,\n",
+      "    \"elapsedMs\": 0,\n",
+      "    \"fileArguments\": {\n",
+      "      \"search\": \"Zava corporate presentation business description\"\n",
+      "    }\n",
+      "  },\n",
+      "  {\n",
+      "    \"type\": \"modelAnswerSynthesis\",\n",
+      "    \"id\": 5,\n",
+      "    \"inputTokens\": 11427,\n",
+      "    \"outputTokens\": 481,\n",
+      "    \"modelName\": \"gpt-4.1-mini\",\n",
+      "    \"elapsedMs\": 10336\n",
+      "  },\n",
+      "  {\n",
+      "    \"type\": \"agenticReasoning\",\n",
+      "    \"id\": 6,\n",
+      "    \"reasoningTokens\": 60347,\n",
+      "    \"retrievalReasoningEffort\": {\n",
+      "      \"kind\": \"low\"\n",
+      "    }\n",
+      "  }\n",
+      "]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(json.dumps(result.get(\"activity\") or [], indent=2)[:3500])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83637449",
+   "metadata": {},
+   "source": [
+    "### 18c · Inspect the first few references (the citations that ground the answer)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "f274132b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ref_id:0] doc_key=None  page=None\n",
+      "\n",
+      "[ref_id:3] doc_key=None  page=None\n",
+      "\n",
+      "[ref_id:1] doc_key='earth_at_night_508_page_92_verbalized'  page=92\n",
+      "  # Auroras  ## Aurora Lights Up the Night - Antarctica  On July 15, 2012, the VIIRS DNB on the Suomi NPP satellite captured this nighttime view of the aurora australis over Antarctica's Queen Maud Land and the Princess Ragnhild Coast. The sl...\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "for ref in (result.get(\"references\") or [])[:3]:\n",
+    "    src = ref.get(\"sourceData\") or {}\n",
+    "    page_no = src.get(\"page_number\")\n",
+    "    snippet = (src.get(\"page_chunk\") or \"\")[:240].replace(\"\\n\", \" \")\n",
+    "    print(f\"[ref_id:{ref.get('id')}] doc_key={ref.get('docKey')!r}  page={page_no}\")\n",
+    "    if snippet:\n",
+    "        print(f\"  {snippet}{'...' if len(snippet) == 240 else ''}\")\n",
+    "    print()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf324e84",
+   "metadata": {},
+   "source": [
+    "## 19 · Continue the conversation (multi-turn)\n",
+    "\n",
+    "Agentic retrieval is conversation-aware. We append the prior answer and\n",
+    "ask a narrower question — the planner uses the earlier context when\n",
+    "deciding what to retrieve next.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "71d6c9d9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FOLLOW-UP ANSWER\n",
+      "----------------\n",
+      "The different colors observed in auroras at different altitudes are caused by the interaction of energetic charged particles from the Sun with atoms and molecules in Earth's upper atmosphere, primarily oxygen and nitrogen, which emit characteristic colors based on the altitude and type of gas excited.\n",
+      "\n",
+      "Specifically:\n",
+      "- Green auroras are produced when energetic particles excite oxygen atoms at altitudes roughly between 60 and 150 miles (about 100 to 240 kilometers). The excited oxygen atoms emit a bright green light, which is the most common auroral color observed.\n",
+      "- Red auroras appear at higher altitudes, around 150 to 300 miles (240 to 480 kilometers), caused by the excitation of oxygen atoms emitting red light. This red airglow comes from excited oxygen atoms at these higher altitudes.\n",
+      "- Blue and purple tinges can be caused by ionized nitrogen molecules becoming excited, typically at lower altitudes, and their emissions produce purplish or blue colors.\n",
+      "\n",
+      "The colors thus represent emissions from different chemical species and transitions occurring at different atmospheric layers. The green glow is generated predominantly by oxygen at mid to lower auroral altitudes, while red airglow results from oxygen emissions higher in the atmosphere. Nitrogen contributes to variations in color, especially blues and purples, at lower levels [ref_id:0][ref_id:6][ref_id:15]. \n",
+      "\n",
+      "This explains the vivid bands of green and red light in auroras seen from space or the ISS, with green aurora being commonly observed and red light visible at higher altitudes, contributing to the multi-colored displays in Earth's polar skies.\n",
+      "\n",
+      "Activity steps : 7\n",
+      "References     : 26\n"
+     ]
+    }
+   ],
+   "source": [
+    "messages.append({\"role\": \"assistant\", \"content\": first_answer})\n",
+    "messages.append({\"role\": \"user\", \"content\": \"Looking at the auroras described in those references, what causes the different colors observed at different altitudes?\"})\n",
+    "\n",
+    "result2 = retrieve(messages)\n",
+    "print(\"FOLLOW-UP ANSWER\")\n",
+    "print(\"----------------\")\n",
+    "print(answer_text(result2))\n",
+    "print()\n",
+    "print(f\"Activity steps : {len(result2.get('activity') or [])}\")\n",
+    "print(f\"References     : {len(result2.get('references') or [])}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1cf1d21a",
+   "metadata": {},
+   "source": [
+    "## 20 · Talk to the Knowledge Base directly over MCP\n",
+    "\n",
+    "Every Foundry IQ KB exposes itself as a **Model Context Protocol** server\n",
+    "at:\n",
+    "\n",
+    "```\n",
+    "{SEARCH_ENDPOINT}/knowledgebases/{KB_NAME}/mcp?api-version=2026-05-01-preview\n",
+    "```\n",
+    "\n",
+    "Any MCP-capable client — Claude Desktop, VS Code Copilot, the Foundry Agent\n",
+    "Service, the Microsoft Agent Framework, a custom Python script — can call\n",
+    "the same retrieval pipeline using one tool: **`knowledge_base_retrieve`**.\n",
+    "\n",
+    "The transport is plain JSON-RPC 2.0 over HTTP with either JSON or\n",
+    "SSE-streamable responses. Auth is the same Search admin api-key. For\n",
+    "federated KS that need user identity (Remote SharePoint, WorkIQ), you\n",
+    "also pass `x-ms-query-source-authorization: <user OBO token>`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "6f4084de",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tools published by this KB\n",
+      "--------------------------\n",
+      "- knowledge_base_retrieve: Use knowledge_base_retrieve to search for information or documents that must be authoritative and attributable to a source. This knowledge b\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "knowledge_base_retrieve (over MCP)\n",
+      "----------------------------------\n",
+      "The dataset about wildfires visible at night reveals several key observations:\n",
+      "\n",
+      "1. Nighttime satellite images capture active wildfires as bright or illuminated spots on Earth's surface, highlighting fire intensity and location. The lights from these fires can be distinguished from city lights and often are accompanied by visible smoke plumes moving with the wind, aiding in tracking fire spread during the night. For example, on August 29, 2012, the VIIRS DNB instrument on the Suomi NPP satellite recorded large, bright areas from multiple wildfires in Idaho and Montana, with visible smoke plumes moving east and northeast [ref_id:0][ref_id:16].\n",
+      "\n",
+      "2. Night images of major wildfires provide insight into fire size and intensity as well as surrounding urban areas for emergency response. For instance, in the Northwest United States during summer 2015, nighttime imagery showed large fires still less than 40% contained near Washington and Oregon, with visible fire illumination and smoke plumes next to populated cities [ref_id:1][ref_id:3].\n",
+      "\n",
+      "3. Time-series nighttime satellite images can track wildfire progression, peak intensity, and decline. The Rim Fire near Yosemite in 2013 was monitored continuously via nighttime images showing the fire's initial ignition, spread into Yosemite National Park, intensity changes, and eventual containment over several weeks [ref_id:5][ref_id:14].\n",
+      "\n",
+      "4. Wildfires also illuminate regions otherwise dark at night, such as remote areas in Siberia, Australia, and Italy, providing visibility of fire events far from urban centers. The dataset notes that lights detected at night away from cities often come from wildfires, but may also be caused by activities like gas flaring or fishing boats [ref_id:4][ref_id:6][ref_id:7].\n",
+      "\n",
+      "5. The sensitivity of modern sensors like VIIRS allows detecting wildfires reflected as visible light in a spectrum including near-infrared, making it possible to capture even relatively small or isolated fires during nighttime passes [ref_id:8].\n",
+      "\n",
+      "Overall, the dataset demonstrates that nighttime satellite imaging is a powerful tool for detecting, monitoring, and analyzing wildfires worldwide. Fires appear as bright spots with associated smoke at night, enabling continuous observation that supports firefighting and disaster response efforts even in darkness and remote areas [ref_id:0][ref_id:1][ref_id:3][ref_id:5][ref_id:6][ref_id:7][ref_id:8].\n"
+     ]
+    }
+   ],
+   "source": [
+    "MCP_URL = f\"{SEARCH_ENDPOINT}/knowledgebases/{KB_NAME}/mcp?api-version={API_VERSION}\"\n",
+    "MCP_HEADERS = {\n",
+    "    \"api-key\": SEARCH_API_KEY,\n",
+    "    \"Content-Type\": \"application/json\",\n",
+    "    \"Accept\": \"application/json, text/event-stream\",\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def _parse_mcp(response: requests.Response) -> dict:\n",
+    "    ct = response.headers.get(\"Content-Type\", \"\")\n",
+    "    if \"text/event-stream\" in ct:\n",
+    "        for line in response.text.splitlines():\n",
+    "            if line.startswith(\"data: \"):\n",
+    "                return json.loads(line[len(\"data: \"):])\n",
+    "        raise RuntimeError(f\"No data event in SSE response: {response.text[:200]}\")\n",
+    "    return response.json()\n",
+    "\n",
+    "\n",
+    "# tools/list — discover the surface this KB publishes.\n",
+    "list_resp = requests.post(MCP_URL, headers=MCP_HEADERS,\n",
+    "    json={\"jsonrpc\": \"2.0\", \"id\": 1, \"method\": \"tools/list\"}, timeout=60)\n",
+    "list_resp.raise_for_status()\n",
+    "tools_payload = _parse_mcp(list_resp)\n",
+    "print(\"Tools published by this KB\")\n",
+    "print(\"--------------------------\")\n",
+    "for t in tools_payload[\"result\"][\"tools\"]:\n",
+    "    first_line = (t.get(\"description\", \"\") or \"\").splitlines()[0]\n",
+    "    print(f\"- {t['name']}: {first_line[:140]}\")\n",
+    "print()\n",
+    "\n",
+    "# tools/call — same retrieval, JSON-RPC envelope.\n",
+    "call_resp = requests.post(MCP_URL, headers=MCP_HEADERS, json={\n",
+    "    \"jsonrpc\": \"2.0\", \"id\": 2,\n",
+    "    \"method\": \"tools/call\",\n",
+    "    \"params\": {\n",
+    "        \"name\": \"knowledge_base_retrieve\",\n",
+    "        \"arguments\": {\"queries\": [\"What does the dataset show about wildfires visible at night?\"]},\n",
+    "    },\n",
+    "}, timeout=180)\n",
+    "call_resp.raise_for_status()\n",
+    "call_payload = _parse_mcp(call_resp)\n",
+    "\n",
+    "print(\"knowledge_base_retrieve (over MCP)\")\n",
+    "print(\"----------------------------------\")\n",
+    "for block in call_payload[\"result\"].get(\"content\", []):\n",
+    "    if block.get(\"type\") == \"text\":\n",
+    "        print(block[\"text\"])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0950b5c",
+   "metadata": {},
+   "source": [
+    "## 21 · Hero — wire the KB into a Foundry Agent\n",
+    "\n",
+    "The Foundry Agent Service hosts the agent loop, the conversation store,\n",
+    "and the MCP runtime for you. To attach a Foundry IQ KB:\n",
+    "\n",
+    "1. **Create a `RemoteTool` project connection** pointing at the KB's MCP URL.\n",
+    "   `authType=ProjectManagedIdentity` lets the project assume its own\n",
+    "   identity when calling Search — no per-user tokens stored on the connection.\n",
+    "2. **Create an agent** that declares an `mcp` tool referencing the\n",
+    "   connection and allow-lists `knowledge_base_retrieve`.\n",
+    "3. **Create a conversation**, then **POST to `/openai/v1/responses`** with\n",
+    "   the agent reference and user input. The Responses API runs the chain\n",
+    "   and returns a grounded answer.\n",
+    "\n",
+    "> **Auth:** `DefaultAzureCredential`. Run `az login` first. Roles needed:\n",
+    "> *Cognitive Services Contributor* (agent), *Azure AI User* (project\n",
+    "> endpoint), and write access on the project's resource group (connection PUT).\n",
+    "\n",
+    "> **Skip:** if `FOUNDRY_PROJECT_ENDPOINT` is blank, this cell prints a\n",
+    "> skip message and the rest of the notebook still runs.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "5f3ebd8a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Project connection ready: mfiq-cookbook-connection\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Agent ready: mfiq-cookbook-agent\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Foundry agent answer\n",
+      "--------------------\n",
+      "City lights observed from satellites at night are used to track urbanization patterns over time by showing changes in illumination intensity and spatial extent that correspond with human development and electrification. Here are the main ways city lights are used for this purpose:\n",
+      "\n",
+      "1. **Identifying Urban Cores and Expansion:** Nighttime satellite images reveal urban cores as bright light clusters. Over time, increasing brightness and expanding illuminated areas indicate urban growth. For example, in Lucknow, India, between 2012 and 2016, satellite images showed increased brightness and larger areas of illumination, reflecting electrification and urban expansion, including rural villages gaining access to electricity.\n",
+      "\n",
+      "2. **Monitoring Urban Sprawl and Infrastructure:** Comparing nightlight data across years shows urban sprawl and infrastructure changes such as new roads and highways lighting up. Chicago's images from 2003, 2012, and 2016 show increasingly defined city lights and the illumination of the Jane Addams Memorial Tollway, reflecting urban expansion and transportation development.\n",
+      "\n",
+      "3. **Mapping Population Distribution and Connectivity:** Nighttime lights highlight major urban centers, transportation corridors, and population distributions, effectively tracing how urban areas grow and interconnect. In regions like the Indus River corridor and Argentina, illuminated clusters along with lit highways reveal patterns of settlements and infrastructure networks.\n",
+      "\n",
+      "4. **Tracking Electrification and Socioeconomic Development:** Nightlights indicate levels of electrification in urban and rural areas, helping to differentiate levels of development. For example, on the Korean Peninsula, brightly lit South Korea contrasts sharply with mostly dark North Korea, illustrating differences in socioeconomic status.\n",
+      "\n",
+      "5. **Using Various Satellite Sensors for Resolution and Detail:** Different satellite sensors such as OLS and VIIRS provide varied image resolutions and sensitivities that allow for monitoring fine-scale changes in urban lighting, infrastructure development, and rural electrification, giving insights into population growth, economic activity, and energy access.\n",
+      "\n",
+      "Overall, by analyzing changes in nighttime city lights through satellite imagery, researchers can quantitatively and geographically track patterns of urban expansion, infrastructure development, population distribution, and electrification over time at multiple spatial and temporal scales. This method has proven invaluable for urban planning, monitoring economic development, and understanding human impacts on the environment【4:0†source】【4:1†source】【4:2†source】【4:3†source】【4:4†source】【4:10†source】【4:14†source】.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "from azure.identity import DefaultAzureCredential\n",
+    "\n",
+    "project_endpoint = env(\"FOUNDRY_PROJECT_ENDPOINT\", required=False)\n",
+    "project_rid = env(\"FOUNDRY_PROJECT_RESOURCE_ID\", required=False)\n",
+    "agent_name = \"mfiq-cookbook-agent\"\n",
+    "connection_name = \"mfiq-cookbook-connection\"\n",
+    "\n",
+    "if not (project_endpoint and project_rid):\n",
+    "    skip(\"Foundry Agent\", \"set FOUNDRY_PROJECT_ENDPOINT and FOUNDRY_PROJECT_RESOURCE_ID to enable\")\n",
+    "else:\n",
+    "    cred = DefaultAzureCredential()\n",
+    "    arm_token = cred.get_token(\"https://management.azure.com/.default\").token\n",
+    "    foundry_token = cred.get_token(\"https://ai.azure.com/.default\").token\n",
+    "    arm_headers = {\"Authorization\": f\"Bearer {arm_token}\", \"Content-Type\": \"application/json\"}\n",
+    "    foundry_headers = {\"Authorization\": f\"Bearer {foundry_token}\", \"Content-Type\": \"application/json\"}\n",
+    "\n",
+    "    # 1) RemoteTool connection\n",
+    "    conn_url = (\n",
+    "        f\"https://management.azure.com{project_rid}/connections/{connection_name}\"\n",
+    "        f\"?api-version=2025-10-01-preview\"\n",
+    "    )\n",
+    "    conn_body = {\n",
+    "        \"name\": connection_name,\n",
+    "        \"type\": \"Microsoft.MachineLearningServices/workspaces/connections\",\n",
+    "        \"properties\": {\n",
+    "            \"authType\": \"ProjectManagedIdentity\",\n",
+    "            \"category\": \"RemoteTool\",\n",
+    "            \"target\": MCP_URL,\n",
+    "            \"isSharedToAll\": True,\n",
+    "            \"audience\": \"https://search.azure.com/\",\n",
+    "            \"metadata\": {\"ApiType\": \"Azure\"},\n",
+    "        },\n",
+    "    }\n",
+    "    r = requests.put(conn_url, headers=arm_headers, json=conn_body, timeout=60)\n",
+    "    r.raise_for_status()\n",
+    "    created_resources[\"foundry_connection_url\"] = conn_url\n",
+    "    print(f\"Project connection ready: {connection_name}\")\n",
+    "\n",
+    "    # 2) Agent\n",
+    "    agent_url = f\"{project_endpoint}/agents?api-version=v1\"\n",
+    "    agent_body = {\n",
+    "        \"name\": agent_name,\n",
+    "        \"definition\": {\n",
+    "            \"model\": GPT_DEPLOYMENT,\n",
+    "            \"instructions\": (\n",
+    "                \"Always call knowledge_base_retrieve before answering. \"\n",
+    "                \"Preserve [ref_id:N] citations the tool returns. \"\n",
+    "                \"If a question spans multiple sources, integrate them faithfully.\"\n",
+    "            ),\n",
+    "            \"tools\": [\n",
+    "                {\n",
+    "                    \"type\": \"mcp\",\n",
+    "                    \"server_label\": \"knowledge-base\",\n",
+    "                    \"server_url\": MCP_URL,\n",
+    "                    \"require_approval\": \"never\",\n",
+    "                    \"allowed_tools\": [\"knowledge_base_retrieve\"],\n",
+    "                    \"project_connection_id\": connection_name,\n",
+    "                }\n",
+    "            ],\n",
+    "            \"kind\": \"prompt\",\n",
+    "        },\n",
+    "    }\n",
+    "    r = requests.post(agent_url, headers=foundry_headers, json=agent_body, timeout=60)\n",
+    "    if r.status_code == 409:\n",
+    "        requests.delete(f\"{project_endpoint}/agents/{agent_name}?api-version=v1\",\n",
+    "                        headers=foundry_headers, timeout=60)\n",
+    "        time.sleep(1)\n",
+    "        r = requests.post(agent_url, headers=foundry_headers, json=agent_body, timeout=60)\n",
+    "    r.raise_for_status()\n",
+    "    created_resources[\"foundry_agent\"] = agent_name\n",
+    "    print(f\"Agent ready: {agent_name}\")\n",
+    "\n",
+    "    # 3) Conversation + first turn\n",
+    "    r = requests.post(f\"{project_endpoint}/openai/v1/conversations\",\n",
+    "                      headers=foundry_headers, json={}, timeout=30)\n",
+    "    r.raise_for_status()\n",
+    "    conv_id = r.json()[\"id\"]\n",
+    "\n",
+    "    r = requests.post(f\"{project_endpoint}/openai/v1/responses\",\n",
+    "        headers=foundry_headers,\n",
+    "        json={\n",
+    "            \"conversation\": conv_id,\n",
+    "            \"input\": \"How are city lights used to track urbanization patterns over time?\",\n",
+    "            \"agent_reference\": {\"type\": \"agent_reference\", \"name\": agent_name},\n",
+    "        },\n",
+    "        timeout=240,\n",
+    "    )\n",
+    "    r.raise_for_status()\n",
+    "    payload = r.json()\n",
+    "\n",
+    "    chunks = []\n",
+    "    for item in payload.get(\"output\", []):\n",
+    "        if item.get(\"type\") == \"message\":\n",
+    "            for c in item.get(\"content\", []):\n",
+    "                if c.get(\"type\") in (\"output_text\", \"text\"):\n",
+    "                    chunks.append(c.get(\"text\", \"\"))\n",
+    "    print(\"\\nFoundry agent answer\")\n",
+    "    print(\"--------------------\")\n",
+    "    print(\"\\n\".join(chunks) or json.dumps(payload, indent=2)[:1500])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5f198e4",
+   "metadata": {},
+   "source": [
+    "## 22 · Microsoft Agent Framework (secondary)\n",
+    "\n",
+    "The [Microsoft Agent Framework](https://learn.microsoft.com/agent-framework/)\n",
+    "ships first-class MCP transports. To plug the same KB in:\n",
+    "\n",
+    "| Piece | What it does |\n",
+    "|---|---|\n",
+    "| `MCPStreamableHTTPTool` | Connects to the KB MCP endpoint and surfaces `knowledge_base_retrieve` as a tool. |\n",
+    "| `OpenAIChatClient` (Azure mode) | Drives the Azure OpenAI Responses API. |\n",
+    "| `Agent` | The minimal runtime — receives the user message, lets the model decide when to call the tool, returns the final answer. |\n",
+    "\n",
+    "**Two gotchas worth remembering:**\n",
+    "\n",
+    "- The KB MCP server is **stateless** — pass `load_prompts=False` so the\n",
+    "  framework doesn't try to call the unsupported `prompts/list`.\n",
+    "- The api-key (or `x-ms-query-source-authorization` for federated KS)\n",
+    "  must be attached at the HTTP layer. Build an `httpx.AsyncClient(headers=...)`\n",
+    "  and pass it in via `http_client=`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "fe11e331",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Microsoft Agent Framework answer\n",
+      "--------------------------------\n",
+      "Auroras, when observed from orbit at night, create distinct patterns of glowing, wavy curtains or bands of light in Earth's upper atmosphere near the polar regions. These light patterns typically appear as vivid green and red streams flowing in arcs or sweeping bands across the horizon. The auroras may show swirling or slightly jagged, dynamic patterns due to the movement of charged particles in Earth's magnetic field. \n",
+      "\n",
+      "From orbit, auroras can look like flowing bands or ribbons of mostly green light, sometimes with red or blue hues, forming bright arcs or curtains above the poles. During strong geomagnetic storms, these auroral lights may extend farther from the poles and become visible over broader areas. Astronauts on the International Space Station see these auroras as colorful bands above Earth's limb, often with city lights visible below. Overall, the auroral light patterns are dynamic, colorful, and sweeping, illuminating the dark night sky near the poles with ribbons or curtains of light [ref_id:0][ref_id:1][ref_id:2][ref_id:3][ref_id:4][ref_id:9][ref_id:12][ref_id:14].\n"
+     ]
+    }
+   ],
+   "source": [
+    "import warnings, asyncio\n",
+    "warnings.filterwarnings(\"ignore\", message=\".*is experimental.*\")\n",
+    "\n",
+    "import httpx\n",
+    "from agent_framework import Agent, MCPStreamableHTTPTool\n",
+    "from agent_framework_openai import OpenAIChatClient\n",
+    "\n",
+    "\n",
+    "async def run_maf() -> str:\n",
+    "    mcp_http = httpx.AsyncClient(\n",
+    "        headers={\"api-key\": SEARCH_API_KEY, \"Accept\": \"application/json, text/event-stream\"},\n",
+    "        timeout=httpx.Timeout(120.0, connect=30.0),\n",
+    "    )\n",
+    "    try:\n",
+    "        async with MCPStreamableHTTPTool(\n",
+    "            name=\"foundry_iq_kb\",\n",
+    "            url=MCP_URL,\n",
+    "            http_client=mcp_http,\n",
+    "            allowed_tools=[\"knowledge_base_retrieve\"],\n",
+    "            approval_mode=\"never_require\",\n",
+    "            load_prompts=False,\n",
+    "        ) as kb_tool:\n",
+    "            chat_client = OpenAIChatClient(\n",
+    "                azure_endpoint=AOAI_ENDPOINT,\n",
+    "                api_key=AOAI_API_KEY,\n",
+    "                api_version=\"preview\",\n",
+    "                model=GPT_DEPLOYMENT,\n",
+    "            )\n",
+    "            agent = Agent(\n",
+    "                client=chat_client,\n",
+    "                name=\"MasteringFoundryIqAgent\",\n",
+    "                instructions=(\n",
+    "                    \"You are a grounded research assistant. For every user question, \"\n",
+    "                    \"call foundry_iq_kb-knowledge_base_retrieve first and answer only \"\n",
+    "                    \"with information returned by the tool. Always preserve the \"\n",
+    "                    \"[ref_id:N] citations the tool returns.\"\n",
+    "                ),\n",
+    "                tools=kb_tool,\n",
+    "            )\n",
+    "            response = await agent.run(\n",
+    "                \"What patterns of light do auroras create when observed from orbit at night?\"\n",
+    "            )\n",
+    "            return response.text\n",
+    "    finally:\n",
+    "        await mcp_http.aclose()\n",
+    "\n",
+    "\n",
+    "maf_answer = await run_maf()\n",
+    "print(\"Microsoft Agent Framework answer\")\n",
+    "print(\"--------------------------------\")\n",
+    "print(maf_answer)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dea66a06",
+   "metadata": {},
+   "source": [
+    "## 23 · Clean up\n",
+    "\n",
+    "The KB, every KS, the sample index, the Foundry agent, and the Foundry\n",
+    "project connection are all chargeable. We delete them in dependency order\n",
+    "so a re-run starts from a blank slate.\n",
+    "\n",
+    "Comment this cell out if you want to keep the KB for further experimentation.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "36945b77",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleted Foundry agent: mfiq-cookbook-agent\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleted Foundry project connection.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleted KB mfiq-master-kb (HTTP 204)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleted KS mfiq-ks-search-index (HTTP 204)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleted KS mfiq-ks-blob (HTTP 204)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleted KS mfiq-ks-file (HTTP 204)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleted KS mfiq-ks-onelake (HTTP 204)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleted KS mfiq-ks-sp-indexed (HTTP 204)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleted KS mfiq-ks-sp-remote (HTTP 204)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleted KS mfiq-ks-sql (HTTP 204)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleted KS mfiq-ks-web (HTTP 204)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleted KS mfiq-ks-fabric-data-agent (HTTP 204)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleted KS mfiq-ks-fabric-ontology (HTTP 204)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleted KS mfiq-ks-workiq (HTTP 204)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleted KS mfiq-ks-mcp-learn (HTTP 204)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleted index mfiq-earth-at-night\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 1) Delete the Foundry agent + project connection (best-effort).\n",
+    "if created_resources.get(\"foundry_agent\"):\n",
+    "    try:\n",
+    "        cred = DefaultAzureCredential()\n",
+    "        foundry_token = cred.get_token(\"https://ai.azure.com/.default\").token\n",
+    "        arm_token = cred.get_token(\"https://management.azure.com/.default\").token\n",
+    "        requests.delete(\n",
+    "            f\"{project_endpoint}/agents/{created_resources['foundry_agent']}?api-version=v1\",\n",
+    "            headers={\"Authorization\": f\"Bearer {foundry_token}\"}, timeout=60,\n",
+    "        )\n",
+    "        print(f\"Deleted Foundry agent: {created_resources['foundry_agent']}\")\n",
+    "        requests.delete(\n",
+    "            created_resources[\"foundry_connection_url\"],\n",
+    "            headers={\"Authorization\": f\"Bearer {arm_token}\"}, timeout=60,\n",
+    "        )\n",
+    "        print(\"Deleted Foundry project connection.\")\n",
+    "    except Exception as exc:\n",
+    "        print(f\"Foundry cleanup partial: {exc}\")\n",
+    "\n",
+    "# 2) Delete the KB.\n",
+    "if created_resources.get(\"kb\"):\n",
+    "    r = requests.delete(kb_url(created_resources[\"kb\"]), headers=SEARCH_HEADERS, timeout=60)\n",
+    "    print(f\"Deleted KB {created_resources['kb']} (HTTP {r.status_code})\")\n",
+    "\n",
+    "# 3) Delete every KS we created.\n",
+    "for ks in created_ks:\n",
+    "    r = requests.delete(ks_url(ks), headers=SEARCH_HEADERS, timeout=60)\n",
+    "    print(f\"Deleted KS {ks} (HTTP {r.status_code})\")\n",
+    "\n",
+    "# 4) Delete the sample index.\n",
+    "if created_resources.get(\"index\"):\n",
+    "    try:\n",
+    "        index_client.delete_index(created_resources[\"index\"])\n",
+    "        print(f\"Deleted index {created_resources['index']}\")\n",
+    "    except Exception as exc:\n",
+    "        print(f\"Index delete: {exc}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a67776e",
+   "metadata": {},
+   "source": [
+    "## 24 · Next steps\n",
+    "\n",
+    "You now have the full **Index → KS (× many) → KB → Agent** pipeline working\n",
+    "with agentic retrieval, multi-turn context, answer synthesis, and both\n",
+    "Foundry Agent + Microsoft Agent Framework consumers. From here:\n",
+    "\n",
+    "- **Productionize Foundry Agent auth** — Step 21 used `ProjectManagedIdentity`.\n",
+    "  For federated KS (Remote SharePoint, WorkIQ) wire **per-user OBO** by\n",
+    "  passing `x-ms-query-source-authorization` via `structured_inputs`.\n",
+    "  See: [Connect a knowledge base to a Foundry agent](https://learn.microsoft.com/azure/foundry/agents/how-to/foundry-iq-connect).\n",
+    "- **Add Purview ACL trim** to your indexed KS (Blob, OneLake, SP, SQL) by\n",
+    "  setting `ingestionPermissionOptions=[\"userIds\",\"groupIds\"]` and passing the\n",
+    "  same OBO header at retrieve time.\n",
+    "- **Tune retrieval** — raise `retrievalReasoningEffort` to `medium` for\n",
+    "  hard queries; switch `outputMode` to `extractiveData` if you want raw\n",
+    "  chunks for a downstream model.\n",
+    "- **Move to Managed Identity end-to-end** — swap `AzureKeyCredential` for\n",
+    "  `DefaultAzureCredential` and assign *Search Service Contributor*,\n",
+    "  *Search Index Data Contributor*, *Cognitive Services User*.\n",
+    "- **Private networking** — see the validated private-KB pattern in\n",
+    "  `Foundry_IQ_Private_Knowledge_Base_with_Foundry_Standard_Agent_Setup`.\n",
+    "\n",
+    "### Reference docs\n",
+    "\n",
+    "- [Agentic retrieval overview](https://learn.microsoft.com/azure/search/agentic-retrieval-overview)\n",
+    "- [Knowledge Source overview](https://learn.microsoft.com/azure/search/agentic-knowledge-source-overview)\n",
+    "- [Create a Knowledge Base](https://learn.microsoft.com/azure/search/agentic-retrieval-how-to-create-knowledge-base)\n",
+    "- [Answer synthesis](https://learn.microsoft.com/azure/search/agentic-retrieval-how-to-answer-synthesis)\n",
+    "- [Connect a KB to a Foundry agent](https://learn.microsoft.com/azure/foundry/agents/how-to/foundry-iq-connect)\n",
+    "- [Migration: 2025-08 → 2025-11 (`knowledgeAgents` → `knowledgeBases`)](https://learn.microsoft.com/azure/search/agentic-retrieval-how-to-migrate)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/registry.yaml
+++ b/registry.yaml
@@ -86,3 +86,16 @@
     - models
     - inference
     - multimodal
+
+- slug: mastering-foundry-iq
+  path: notebooks/mastering-foundry-iq.ipynb
+  title: "Mastering Foundry IQ"
+  description: "End-to-end Foundry IQ walkthrough: every Knowledge Source type, one unified Knowledge Base, and integrations with Foundry Agent Service and Microsoft Agent Framework."
+  date: "2026-05-27"
+  authors:
+    - github: farzad528
+  tags:
+    - knowledge
+    - agents
+    - agent-framework
+    - mcp


### PR DESCRIPTION
## Description

Adds a comprehensive **Mastering Foundry IQ** cookbook — an end-to-end walkthrough of every Knowledge Source type on the `2026-05-01-preview` Search API, assembled into one unified Knowledge Base, and wired into both **Foundry Agent Service** (hero scenario) and a **Microsoft Agent Framework** agent.

**What you'll learn:**

1. Provision a Search index with vector + semantic configuration
2. Create one Knowledge Source per supported type: Search Index · Azure Blob · File · Indexed OneLake · Indexed SharePoint · Remote SharePoint · Indexed SQL · Web · Fabric Data Agent · Fabric Ontology · WorkIQ · MCP Server
3. Assemble one Knowledge Base that fans out to every KS configured
4. Run a complex multi-part query and inspect the planner's activity + citations
5. Continue the conversation multi-turn
6. Talk to the KB directly over MCP (`tools/list` + `tools/call`)
7. Wire the KB into a Foundry Agent (`RemoteTool` connection + Responses API)
8. Wire the same KB into a Microsoft Agent Framework agent (`MCPStreamableHTTPTool`)
9. Clean up every resource the notebook created

Every Knowledge Source section is **independently skippable** — leave its env vars blank and the notebook prints a skip message and moves on.

**Files changed:**

| File | Change |
|---|---|
| `notebooks/mastering-foundry-iq.ipynb` | new |
| `registry.yaml` | append entry · slug `mastering-foundry-iq` · tags `knowledge`, `agents`, `agent-framework`, `mcp` |
| `authors.yaml` | add `farzad528` (Farzad Sunavala, Principal Product Manager) |

**Notebook adjustments to match repo conventions:**

- Stripped leading `# H1` (title is rendered from `registry.yaml`)
- Inlined `%pip install` of the pinned alpha `azure-search-documents` SDK with the Azure SDK public `--extra-index-url` — no sidecar `requirements.txt` / `pip.ini`
- Rewrote prerequisites prose to list env vars inline (no `.env.example` sidecar)
- Scrubbed personal Search and AOAI endpoint URLs from cell outputs
- Stripped per-cell execution timestamp metadata

Closes #

---

## Checklist

### Notebook contributions

- [x] Notebook added to `notebooks/` directory
- [x] Entry added to `registry.yaml` with all required fields (`slug`, `path`, `title`, `authors`)
- [x] Author entry exists in `authors.yaml` (with at least `name` and `title`)
- [x] Tags are from the allowed list in `tags.yaml` (`knowledge`, `agents`, `agent-framework`, `mcp`)
- [x] Registry validation passes: `cd scripts && npx tsx validate-registry.ts` — 7 notebooks validated, zero errors
- [x] Notebook runs cleanly end-to-end <!-- source notebook was executed end-to-end before contribution; no re-execution performed in this PR -->
- [ ] Cell outputs cleared before committing <!-- intentionally preserved outputs (matches the other Foundry recipes) with personal Search + AOAI endpoint URLs scrubbed to generic placeholders -->
- [x] No site-specific metadata inside the notebook
- [x] Images stored in `notebooks/media/` with descriptive alt text <!-- N/A — this notebook embeds no local images; it fetches its sample dataset from a public NASA URL at runtime -->

### Site changes

- [x] Site builds without errors: `cd site && npm run build` — 8 pages built, 0 errors