### PR TITLE
Improve Forgebook recipe page rendering

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,10 @@
+# Microsoft Open Source Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+
+Resources:
+
+- [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
+- [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+- Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or concerns
+- Employees can reach out at [aka.ms/opensource/moderation-support](https://aka.ms/opensource/moderation-support)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Recipes cover a range of AI development topics:
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the current authoring workflow and review checklist.
 
+This project follows the [Microsoft Open Source Code of Conduct](CODE_OF_CONDUCT.md). For support options, see [SUPPORT.md](SUPPORT.md). To report security vulnerabilities, see [SECURITY.md](SECURITY.md).
+
 ## License
 
 [MIT](LICENSE)

--- a/site/src/components/NotebookActions.astro
+++ b/site/src/components/NotebookActions.astro
@@ -17,57 +17,35 @@ const vscodeInsidersUrl = `https://insiders.vscode.dev/github/microsoft-foundry/
 ---
 
 <div class="flex flex-wrap gap-3">
-  <a
-    id="github-btn"
-    href={githubUrl}
-    target="_blank"
-    rel="noopener noreferrer"
-    data-slug={slug}
-    class="notebook-action hc-hover inline-flex items-center gap-2 px-4 py-2 text-sm font-medium btn-primary rounded-lg transition-colors"
-  >
-    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-      <path
-        d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
-      ></path>
-    </svg>
-    Open in GitHub
-  </a>
-
-  <!-- Open in VS Code Button with Dropdown -->
-  <div class="relative" id="vscode-container">
+  <!-- Open button group (GitHub primary + VS Code dropdown) -->
+  <div class="relative" id="open-container">
     <div class="inline-flex items-center">
       <a
-        id="vscode-main-btn"
-        href={vscodeUrl}
+        id="github-btn"
+        href={githubUrl}
         target="_blank"
         rel="noopener noreferrer"
-        class="notebook-action hc-hover inline-flex items-center gap-2 px-4 py-2 text-sm font-medium btn-secondary rounded-l-lg transition-colors"
-        aria-label="Open in VS Code"
         data-slug={slug}
-        data-vscode-url={vscodeUrl}
-        data-insiders-url={vscodeInsidersUrl}
+        class="notebook-action hc-hover inline-flex items-center gap-2 px-4 py-2 text-sm font-medium btn-primary rounded-l-lg transition-colors border-r-0"
       >
-        <span>Open in</span>
-        <!-- VS Code Stable icon -->
-        <svg class="w-4 h-4" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="VS Code">
-          <mask id="vsc-s-mask" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="100" height="100">
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M70.9119 99.3171C72.4869 99.9307 74.2828 99.8914 75.8725 99.1264L96.4608 89.2197C98.6242 88.1787 100 85.9892 100 83.5872V16.4133C100 14.0113 98.6243 11.8218 96.4609 10.7808L75.8725 0.873756C73.7862 -0.130129 71.3446 0.11576 69.5135 1.44695C69.252 1.63711 69.0028 1.84943 68.769 2.08341L29.3551 38.0415L12.1872 25.0096C10.589 23.7965 8.35363 23.8959 6.86933 25.2461L1.36303 30.2549C-0.452552 31.9064 -0.454633 34.7627 1.35853 36.417L16.2471 50.0001L1.35853 63.5832C-0.454633 65.2374 -0.452552 68.0938 1.36303 69.7453L6.86933 74.7541C8.35363 76.1043 10.589 76.2037 12.1872 74.9905L29.3551 61.9587L68.769 97.9167C69.3925 98.5406 70.1246 99.0104 70.9119 99.3171ZM75.0152 27.2989L45.1091 50.0001L75.0152 72.7012V27.2989Z" fill="white"/>
-          </mask>
-          <g mask="url(#vsc-s-mask)">
-            <path d="M96.4614 10.7962L75.8569 0.875542C73.4719 -0.272773 70.6217 0.211611 68.75 2.08333L1.29858 63.5832C-0.515693 65.2373 -0.513607 68.0937 1.30308 69.7452L6.81272 74.754C8.29793 76.1042 10.5347 76.2036 12.1338 74.9905L93.3609 13.3699C96.086 11.3026 100 13.2462 100 16.6667V16.4275C100 14.0265 98.6246 11.8378 96.4614 10.7962Z" fill="#0065A9"/>
-            <path d="M96.4614 89.2038L75.8569 99.1245C73.4719 100.273 70.6217 99.7884 68.75 97.9167L1.29858 36.4169C-0.515693 34.7627 -0.513607 31.9063 1.30308 30.2548L6.81272 25.246C8.29793 23.8958 10.5347 23.7964 12.1338 25.0095L93.3609 86.6301C96.086 88.6974 100 86.7538 100 83.3334V83.5726C100 85.9735 98.6246 88.1622 96.4614 89.2038Z" fill="#007ACC"/>
-            <path d="M75.8578 99.1263C73.4721 100.274 70.6219 99.7885 68.75 97.9166C71.0564 100.223 75 98.5895 75 95.3278V4.67213C75 1.41039 71.0564 -0.223106 68.75 2.08329C70.6219 0.211402 73.4721 -0.273666 75.8578 0.873633L96.4587 10.7807C98.6234 11.8217 100 14.0112 100 16.4132V83.5871C100 85.9891 98.6234 88.1786 96.4586 89.2196L75.8578 99.1263Z" fill="#1F9CF0"/>
-          </g>
+        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path
+            d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
+          ></path>
         </svg>
+        Open in GitHub
       </a>
       <button
         id="vscode-dropdown-btn"
-        class="notebook-action hc-hover inline-flex items-center px-2 py-2 text-sm font-medium btn-secondary rounded-r-lg transition-colors cursor-pointer"
+        data-slug={slug}
+        data-vscode-url={vscodeUrl}
+        data-insiders-url={vscodeInsidersUrl}
+        class="notebook-action hc-hover inline-flex items-center px-2 py-2 text-sm font-medium btn-primary rounded-r-lg transition-colors cursor-pointer"
         aria-haspopup="menu"
         aria-expanded="false"
-        aria-label="Select VS Code version"
+        aria-label="Open options"
       >
-        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
         </svg>
       </button>
@@ -75,16 +53,16 @@ const vscodeInsidersUrl = `https://insiders.vscode.dev/github/microsoft-foundry/
 
     <div
       id="vscode-dropdown"
-      class="absolute left-0 mt-2 w-60 dropdown-menu rounded-lg shadow-lg py-1 z-50 hidden"
+      class="absolute left-0 mt-2 w-80 max-w-[calc(100vw-2rem)] dropdown-menu rounded-lg shadow-lg py-1 z-50 hidden"
       role="menu"
-      aria-label="VS Code version"
+      aria-label="Open options"
     >
       <button
         role="menuitem"
         data-version="stable"
-        class="vscode-version-option dropdown-item w-full flex items-center gap-3 px-4 py-2 text-sm transition-colors text-left"
+        class="vscode-version-option dropdown-item w-full flex items-center gap-3 px-4 py-2 text-sm transition-colors text-left whitespace-nowrap"
       >
-        <svg class="w-4 h-4 flex-shrink-0" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg class="w-4 h-4 flex-shrink-0" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
           <mask id="vs-stable-mask" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="100" height="100">
             <path fill-rule="evenodd" clip-rule="evenodd" d="M70.9119 99.3171C72.4869 99.9307 74.2828 99.8914 75.8725 99.1264L96.4608 89.2197C98.6242 88.1787 100 85.9892 100 83.5872V16.4133C100 14.0113 98.6243 11.8218 96.4609 10.7808L75.8725 0.873756C73.7862 -0.130129 71.3446 0.11576 69.5135 1.44695C69.252 1.63711 69.0028 1.84943 68.769 2.08341L29.3551 38.0415L12.1872 25.0096C10.589 23.7965 8.35363 23.8959 6.86933 25.2461L1.36303 30.2549C-0.452552 31.9064 -0.454633 34.7627 1.35853 36.417L16.2471 50.0001L1.35853 63.5832C-0.454633 65.2374 -0.452552 68.0938 1.36303 69.7453L6.86933 74.7541C8.35363 76.1043 10.589 76.2037 12.1872 74.9905L29.3551 61.9587L68.769 97.9167C69.3925 98.5406 70.1246 99.0104 70.9119 99.3171ZM75.0152 27.2989L45.1091 50.0001L75.0152 72.7012V27.2989Z" fill="white"/>
           </mask>
@@ -94,14 +72,14 @@ const vscodeInsidersUrl = `https://insiders.vscode.dev/github/microsoft-foundry/
             <path d="M75.8578 99.1263C73.4721 100.274 70.6219 99.7885 68.75 97.9166C71.0564 100.223 75 98.5895 75 95.3278V4.67213C75 1.41039 71.0564 -0.223106 68.75 2.08329C70.6219 0.211402 73.4721 -0.273666 75.8578 0.873633L96.4587 10.7807C98.6234 11.8217 100 14.0112 100 16.4132V83.5871C100 85.9891 98.6234 88.1786 96.4586 89.2196L75.8578 99.1263Z" fill="#1F9CF0"/>
           </g>
         </svg>
-        <span>Open in VS Code</span>
+        <span>Open in VS Code for the Web</span>
       </button>
       <button
         role="menuitem"
         data-version="insiders"
-        class="vscode-version-option dropdown-item w-full flex items-center gap-3 px-4 py-2 text-sm transition-colors text-left"
+        class="vscode-version-option dropdown-item w-full flex items-center gap-3 px-4 py-2 text-sm transition-colors text-left whitespace-nowrap"
       >
-        <svg class="w-4 h-4 flex-shrink-0" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg class="w-4 h-4 flex-shrink-0" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
           <mask id="vs-insiders-mask" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="100" height="100">
             <path fill-rule="evenodd" clip-rule="evenodd" d="M70.9119 99.3171C72.4869 99.9307 74.2828 99.8914 75.8725 99.1264L96.4608 89.2197C98.6242 88.1787 100 85.9892 100 83.5872V16.4133C100 14.0113 98.6243 11.8218 96.4609 10.7808L75.8725 0.873756C73.7862 -0.130129 71.3446 0.11576 69.5135 1.44695C69.252 1.63711 69.0028 1.84943 68.769 2.08341L29.3551 38.0415L12.1872 25.0096C10.589 23.7965 8.35363 23.8959 6.86933 25.2461L1.36303 30.2549C-0.452552 31.9064 -0.454633 34.7627 1.35853 36.417L16.2471 50.0001L1.35853 63.5832C-0.454633 65.2374 -0.452552 68.0938 1.36303 69.7453L6.86933 74.7541C8.35363 76.1043 10.589 76.2037 12.1872 74.9905L29.3551 61.9587L68.769 97.9167C69.3925 98.5406 70.1246 99.0104 70.9119 99.3171ZM75.0152 27.2989L45.1091 50.0001L75.0152 72.7012V27.2989Z" fill="white"/>
           </mask>
@@ -111,7 +89,7 @@ const vscodeInsidersUrl = `https://insiders.vscode.dev/github/microsoft-foundry/
             <path d="M75.8578 99.1263C73.4721 100.274 70.6219 99.7885 68.75 97.9166C71.0564 100.223 75 98.5895 75 95.3278V4.67213C75 1.41039 71.0564 -0.223106 68.75 2.08329C70.6219 0.211402 73.4721 -0.273666 75.8578 0.873633L96.4587 10.7807C98.6234 11.8217 100 14.0112 100 16.4132V83.5871C100 85.9891 98.6234 88.1786 96.4586 89.2196L75.8578 99.1263Z" fill="#24bfa5"/>
           </g>
         </svg>
-        <span>Open in VS Code Insiders</span>
+        <span>Open in VS Code Insiders for the Web</span>
       </button>
     </div>
   </div>
@@ -123,15 +101,12 @@ const vscodeInsidersUrl = `https://insiders.vscode.dev/github/microsoft-foundry/
         id="copy-markdown-btn"
         data-slug={slug}
         class="notebook-action hc-hover inline-flex items-center gap-2 px-4 py-2 text-sm font-medium btn-secondary rounded-l-lg transition-colors cursor-pointer border-r-0"
-        aria-label="Copy Markdown"
+        aria-label="Copy page"
       >
-        <span id="copy-btn-text">Copy</span>
-        <span class="markdown-badge badge inline-flex items-center rounded px-1.5 py-0.5" aria-hidden="true">
-          <svg class="markdown-logo h-3.5 w-5" viewBox="0 0 208 128" xmlns="http://www.w3.org/2000/svg">
-            <path fill="none" stroke="currentColor" stroke-width="10" d="M15,5h178c5.523,0,10,4.477,10,10v98c0,5.523-4.477,10-10,10H15c-5.523,0-10-4.477-10-10V15C5,9.477,9.477,5,15,5z" />
-            <path fill="currentColor" d="M30,98V30h20l20,25l20-25h20v68H90V59L70,84L50,59v39H30z M155,98l-30-33h20V30h20v35h20L155,98z" />
-          </svg>
-        </span>
+        <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
+          <path fill="currentColor" d="M5.503 4.627L5.5 6.75v10.504a3.25 3.25 0 0 0 3.25 3.25h8.616a2.25 2.25 0 0 1-2.122 1.5H8.75A4.75 4.75 0 0 1 4 17.254V6.75c0-.98.627-1.815 1.503-2.123M17.75 2A2.25 2.25 0 0 1 20 4.25v13a2.25 2.25 0 0 1-2.25 2.25h-9a2.25 2.25 0 0 1-2.25-2.25v-13A2.25 2.25 0 0 1 8.75 2zm0 1.5h-9a.75.75 0 0 0-.75.75v13c0 .414.336.75.75.75h9a.75.75 0 0 0 .75-.75v-13a.75.75 0 0 0-.75-.75" />
+        </svg>
+        <span id="copy-btn-text" class="hidden sm:inline">Copy page</span>
       </button>
       <button
         id="markdown-dropdown-btn"
@@ -140,7 +115,7 @@ const vscodeInsidersUrl = `https://insiders.vscode.dev/github/microsoft-foundry/
         aria-expanded="false"
         aria-label="Markdown options"
       >
-        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
         </svg>
       </button>
@@ -157,7 +132,7 @@ const vscodeInsidersUrl = `https://insiders.vscode.dev/github/microsoft-foundry/
         class="dropdown-item w-full flex items-center gap-3 px-4 py-2 text-sm transition-colors text-left"
         role="menuitem"
       >
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
         </svg>
         <span id="dropdown-copy-text">Copy in Markdown</span>
@@ -170,7 +145,7 @@ const vscodeInsidersUrl = `https://insiders.vscode.dev/github/microsoft-foundry/
         class="dropdown-item flex items-center gap-3 px-4 py-2 text-sm transition-colors"
         role="menuitem"
       >
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
         </svg>
@@ -181,30 +156,38 @@ const vscodeInsidersUrl = `https://insiders.vscode.dev/github/microsoft-foundry/
 
   <!-- Share Button with Dropdown -->
   <div class="relative" id="share-container">
-    <button
-      id="share-btn"
-      data-slug={slug}
-      data-share-url={shareUrl}
-      data-share-title={title}
-      class="notebook-action hc-hover inline-flex items-center gap-2 px-4 py-2 text-sm font-medium btn-secondary rounded-lg transition-colors cursor-pointer"
-      aria-haspopup="true"
-      aria-expanded="false"
-    >
-      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
-        ></path>
-      </svg>
-      <span class="sr-only">Share</span>
-      <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-      </svg>
-    </button>
+    <div class="inline-flex items-center">
+      <button
+        id="share-btn"
+        data-slug={slug}
+        data-share-url={shareUrl}
+        data-share-title={title}
+        class="notebook-action hc-hover inline-flex items-center gap-2 px-4 py-2 text-sm font-medium btn-secondary rounded-l-lg transition-colors cursor-pointer border-r-0"
+        aria-label="Share"
+      >
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
+          ></path>
+        </svg>
+        <span id="share-btn-text" class="hidden sm:inline">Share</span>
+      </button>
+      <button
+        id="share-dropdown-btn"
+        class="notebook-action hc-hover inline-flex items-center px-2 py-2 text-sm font-medium btn-secondary rounded-r-lg transition-colors cursor-pointer"
+        aria-haspopup="true"
+        aria-expanded="false"
+        aria-label="Share options"
+      >
+        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+        </svg>
+      </button>
+    </div>
 
-    <!-- Dropdown Menu -->
     <div
       id="share-dropdown"
       class="absolute right-0 mt-2 w-48 dropdown-menu rounded-lg shadow-lg py-1 z-50 hidden"
@@ -215,7 +198,7 @@ const vscodeInsidersUrl = `https://insiders.vscode.dev/github/microsoft-foundry/
         class="share-menu-item dropdown-item w-full flex items-center gap-3 px-4 py-2 text-sm transition-colors text-left"
         role="menuitem"
       >
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"></path>
         </svg>
         <span id="copy-link-text">Copy Link</span>
@@ -229,7 +212,7 @@ const vscodeInsidersUrl = `https://insiders.vscode.dev/github/microsoft-foundry/
         class="share-menu-item dropdown-item flex items-center gap-3 px-4 py-2 text-sm transition-colors"
         role="menuitem"
       >
-        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"></path>
         </svg>
         Share on X
@@ -243,7 +226,7 @@ const vscodeInsidersUrl = `https://insiders.vscode.dev/github/microsoft-foundry/
         class="share-menu-item dropdown-item flex items-center gap-3 px-4 py-2 text-sm transition-colors"
         role="menuitem"
       >
-        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"></path>
         </svg>
         Share on LinkedIn
@@ -254,7 +237,7 @@ const vscodeInsidersUrl = `https://insiders.vscode.dev/github/microsoft-foundry/
         class="share-menu-item dropdown-item hidden w-full items-center gap-3 px-4 py-2 text-sm transition-colors text-left border-t border-subtle mt-1 pt-2"
         role="menuitem"
       >
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"></path>
         </svg>
         More options...
@@ -269,60 +252,43 @@ const vscodeInsidersUrl = `https://insiders.vscode.dev/github/microsoft-foundry/
   const baseUrl = import.meta.env.BASE_URL.replace(/\/$/, "");
 
   // -----------------------------------------------------------------------
-  // VS Code button group (main open button + version dropdown)
+  // Open button group (GitHub primary + VS Code dropdown)
   // -----------------------------------------------------------------------
-  const vscodeMainBtn = document.getElementById("vscode-main-btn") as HTMLAnchorElement | null;
-  const vscodeDropdownBtn = document.getElementById("vscode-dropdown-btn");
+  const githubBtn = document.getElementById("github-btn");
+  const vscodeDropdownBtn = document.getElementById("vscode-dropdown-btn") as HTMLElement | null;
   const vscodeDropdown = document.getElementById("vscode-dropdown");
   const vscodeVersionOptions = document.querySelectorAll(".vscode-version-option");
 
-  // Toggle VS Code dropdown
+  githubBtn?.addEventListener("click", () => {
+    trackEvent("OpenInGitHub", { slug: githubBtn.getAttribute("data-slug") ?? "unknown" });
+  });
+
   vscodeDropdownBtn?.addEventListener("click", (e) => {
     e.stopPropagation();
     const isHidden = vscodeDropdown?.classList.contains("hidden");
-    // Close other dropdowns
     mdDropdown?.classList.add("hidden");
     mdDropdownBtn?.setAttribute("aria-expanded", "false");
     shareDropdown?.classList.add("hidden");
-    shareBtn?.setAttribute("aria-expanded", "false");
+    shareDropdownBtn?.setAttribute("aria-expanded", "false");
     vscodeDropdown?.classList.toggle("hidden", !isHidden);
     vscodeDropdownBtn.setAttribute("aria-expanded", isHidden ? "true" : "false");
   });
 
-  // Handle version selection — navigate immediately
   vscodeVersionOptions.forEach((option) => {
     option.addEventListener("click", () => {
       const version = (option as HTMLElement).dataset.version;
       const isInsiders = version === "insiders";
+      const stableUrl = vscodeDropdownBtn?.dataset.vscodeUrl || "";
+      const insidersUrl = vscodeDropdownBtn?.dataset.insidersUrl || "";
+      const url = isInsiders ? insidersUrl : stableUrl;
 
-      if (vscodeMainBtn) {
-        const stableUrl = vscodeMainBtn.dataset.vscodeUrl || "";
-        const insidersUrl = vscodeMainBtn.dataset.insidersUrl || "";
-        const url = isInsiders ? insidersUrl : stableUrl;
-
-        trackEvent("OpenInVSCode", { version: version ?? "stable", action: "dropdown", slug: vscodeMainBtn.dataset.slug ?? "unknown" });
-
-        // Close dropdown and navigate
+      if (url) {
+        trackEvent("OpenInVSCode", { version: version ?? "stable", action: "dropdown", slug: vscodeDropdownBtn?.dataset.slug ?? "unknown" });
         vscodeDropdown?.classList.add("hidden");
         vscodeDropdownBtn?.setAttribute("aria-expanded", "false");
         window.open(url, "_blank", "noopener,noreferrer");
       }
     });
-  });
-
-  // Track main button clicks
-  vscodeMainBtn?.addEventListener("click", () => {
-    const isInsiders = vscodeMainBtn.href.includes("insiders.vscode.dev");
-    const slug = vscodeMainBtn.dataset.slug ?? "unknown";
-    trackEvent("OpenInVSCode", { version: isInsiders ? "insiders" : "stable", action: "click", slug });
-  });
-
-  // -----------------------------------------------------------------------
-  // Open in GitHub tracking
-  // -----------------------------------------------------------------------
-  const githubBtn = document.getElementById("github-btn");
-  githubBtn?.addEventListener("click", () => {
-    trackEvent("OpenInGitHub", { slug: githubBtn.getAttribute("data-slug") ?? "unknown" });
   });
 
   // -----------------------------------------------------------------------
@@ -351,52 +317,49 @@ const vscodeInsidersUrl = `https://insiders.vscode.dev/github/microsoft-foundry/
     }
   }
 
-  // Main button — copy markdown
   copyBtn?.addEventListener("click", () => {
-    copyMarkdown(copyBtn.getAttribute("data-slug"), copyBtnText, "Copy", "button");
+    copyMarkdown(copyBtn.getAttribute("data-slug"), copyBtnText, "Copy page", "button");
   });
 
-  // Dropdown copy option
   dropdownCopyBtn?.addEventListener("click", () => {
     copyMarkdown(dropdownCopyBtn.getAttribute("data-slug"), dropdownCopyText, "Copy in Markdown", "dropdown");
     mdDropdown?.classList.add("hidden");
     mdDropdownBtn?.setAttribute("aria-expanded", "false");
   });
 
-  // Toggle markdown dropdown
   mdDropdownBtn?.addEventListener("click", (e) => {
     e.stopPropagation();
     const isHidden = mdDropdown?.classList.contains("hidden");
-    // Close other dropdowns
     shareDropdown?.classList.add("hidden");
-    shareBtn?.setAttribute("aria-expanded", "false");
+    shareDropdownBtn?.setAttribute("aria-expanded", "false");
     vscodeDropdown?.classList.add("hidden");
     vscodeDropdownBtn?.setAttribute("aria-expanded", "false");
     mdDropdown?.classList.toggle("hidden", !isHidden);
     mdDropdownBtn.setAttribute("aria-expanded", isHidden ? "true" : "false");
   });
 
-  // Prevent dropdown from closing when clicking inside
   mdDropdown?.addEventListener("click", (e) => {
     e.stopPropagation();
   });
 
-  // View in Markdown link tracking
   const viewMarkdownLink = document.getElementById("view-markdown-link");
   viewMarkdownLink?.addEventListener("click", () => {
     trackEvent("ViewMarkdown", { slug: viewMarkdownLink.getAttribute("data-slug") ?? "unknown" });
   });
 
+  // -----------------------------------------------------------------------
   // Share functionality
+  // -----------------------------------------------------------------------
   const shareBtn = document.getElementById("share-btn");
+  const shareBtnText = document.getElementById("share-btn-text");
+  const shareDropdownBtn = document.getElementById("share-dropdown-btn");
   const shareDropdown = document.getElementById("share-dropdown");
   const copyLinkBtn = document.getElementById("copy-link-btn");
   const copyLinkText = document.getElementById("copy-link-text");
-  const shareX = document.getElementById("share-x") as HTMLAnchorElement;
-  const shareLinkedIn = document.getElementById("share-linkedin") as HTMLAnchorElement;
+  const shareX = document.getElementById("share-x") as HTMLAnchorElement | null;
+  const shareLinkedIn = document.getElementById("share-linkedin") as HTMLAnchorElement | null;
   const nativeShareBtn = document.getElementById("native-share-btn");
 
-  // Get the full URL for sharing
   const getShareUrl = () => {
     const path = shareBtn?.getAttribute("data-share-url") || "";
     return new URL(path, window.location.origin).href;
@@ -406,19 +369,36 @@ const vscodeInsidersUrl = `https://insiders.vscode.dev/github/microsoft-foundry/
     return shareBtn?.getAttribute("data-share-title") || document.title;
   };
 
-  // Toggle dropdown
-  shareBtn?.addEventListener("click", (e) => {
+  async function copyShareLink(feedbackEl: HTMLElement | null, defaultText: string, source: "button" | "dropdown") {
+    try {
+      await navigator.clipboard.writeText(getShareUrl());
+      trackEvent("ShareAction", { method: "CopyLink", source, slug: shareBtn?.getAttribute("data-slug") ?? "unknown", url: getShareUrl() });
+      if (feedbackEl) {
+        feedbackEl.textContent = "Copied!";
+        setTimeout(() => {
+          feedbackEl.textContent = defaultText;
+        }, 2000);
+      }
+    } catch (err) {
+      console.error("Failed to copy link:", err);
+      trackError(err, { action: "CopyLink" });
+    }
+  }
+
+  shareBtn?.addEventListener("click", () => {
+    copyShareLink(shareBtnText, "Share", "button");
+  });
+
+  shareDropdownBtn?.addEventListener("click", (e) => {
     e.stopPropagation();
     const isHidden = shareDropdown?.classList.contains("hidden");
-    // Close other dropdowns
     mdDropdown?.classList.add("hidden");
     mdDropdownBtn?.setAttribute("aria-expanded", "false");
     vscodeDropdown?.classList.add("hidden");
     vscodeDropdownBtn?.setAttribute("aria-expanded", "false");
     shareDropdown?.classList.toggle("hidden", !isHidden);
-    shareBtn.setAttribute("aria-expanded", isHidden ? "true" : "false");
+    shareDropdownBtn.setAttribute("aria-expanded", isHidden ? "true" : "false");
 
-    // Update share links with current URL
     if (isHidden) {
       const url = getShareUrl();
       const title = getShareTitle();
@@ -434,39 +414,26 @@ const vscodeInsidersUrl = `https://insiders.vscode.dev/github/microsoft-foundry/
     }
   });
 
-  // Close all dropdowns when clicking outside
   document.addEventListener("click", () => {
     shareDropdown?.classList.add("hidden");
-    shareBtn?.setAttribute("aria-expanded", "false");
+    shareDropdownBtn?.setAttribute("aria-expanded", "false");
     mdDropdown?.classList.add("hidden");
     mdDropdownBtn?.setAttribute("aria-expanded", "false");
     vscodeDropdown?.classList.add("hidden");
     vscodeDropdownBtn?.setAttribute("aria-expanded", "false");
   });
 
-  // Prevent dropdown from closing when clicking inside
   shareDropdown?.addEventListener("click", (e) => {
     e.stopPropagation();
   });
-
-  // Copy link to clipboard
-  copyLinkBtn?.addEventListener("click", async () => {
-    try {
-      await navigator.clipboard.writeText(getShareUrl());
-      trackEvent("ShareAction", { method: "CopyLink", slug: shareBtn?.getAttribute("data-slug") ?? "unknown", url: getShareUrl() });
-      if (copyLinkText) {
-        copyLinkText.textContent = "Copied!";
-        setTimeout(() => {
-          copyLinkText.textContent = "Copy Link";
-        }, 2000);
-      }
-    } catch (err) {
-      console.error("Failed to copy link:", err);
-      trackError(err, { action: "CopyLink" });
-    }
+  vscodeDropdown?.addEventListener("click", (e) => {
+    e.stopPropagation();
   });
 
-  // Track social share link clicks (X, LinkedIn)
+  copyLinkBtn?.addEventListener("click", async () => {
+    copyShareLink(copyLinkText, "Copy Link", "dropdown");
+  });
+
   shareX?.addEventListener("click", () => {
     trackEvent("ShareAction", { method: "X", slug: shareBtn?.getAttribute("data-slug") ?? "unknown", url: getShareUrl() });
   });
@@ -474,7 +441,6 @@ const vscodeInsidersUrl = `https://insiders.vscode.dev/github/microsoft-foundry/
     trackEvent("ShareAction", { method: "LinkedIn", slug: shareBtn?.getAttribute("data-slug") ?? "unknown", url: getShareUrl() });
   });
 
-  // Show native share button if Web Share API is available
   if (navigator.share) {
     nativeShareBtn?.classList.remove("hidden");
     nativeShareBtn?.classList.add("flex");
@@ -488,7 +454,6 @@ const vscodeInsidersUrl = `https://insiders.vscode.dev/github/microsoft-foundry/
         trackEvent("ShareAction", { method: "NativeShare", slug: shareBtn?.getAttribute("data-slug") ?? "unknown", url: getShareUrl() });
         shareDropdown?.classList.add("hidden");
       } catch (err) {
-        // User cancelled or error
         if ((err as Error).name !== "AbortError") {
           console.error("Share failed:", err);
           trackError(err, { action: "NativeShare" });

--- a/site/src/components/NotebookCard.astro
+++ b/site/src/components/NotebookCard.astro
@@ -75,19 +75,101 @@ function tagColor(tag: string): string {
     </div>
     {
       notebook.tags && notebook.tags.length > 0 && (
-        <div class="flex flex-wrap gap-2 mt-4 max-h-[3.5rem] overflow-hidden relative">
-          {notebook.tags.slice(0, 4).map((tag) => (
-                <span class={`px-2 py-1 text-xs rounded-full border font-medium ${tagColor(tag)}`}>
+        <div class="notebook-tags-row" aria-label="Recipe tags">
+          {notebook.tags.map((tag) => (
+                <span class={`notebook-tag-chip px-2 py-1 text-xs rounded-full border font-medium ${tagColor(tag)}`} data-tag-chip title={tag}>
                   {tag}
                 </span>
               ))}
-          {notebook.tags.length > 4 && (
-            <span class="px-2 py-1 text-xs rounded-full border font-medium text-muted border-subtle" title={notebook.tags.slice(4).join(", ")}>
-              +{notebook.tags.length - 4}
-            </span>
-          )}
+          <span class="notebook-tags-overflow px-2 py-1 text-xs rounded-full border font-medium text-muted border-subtle" data-tag-overflow hidden>
+            +0
+          </span>
         </div>
       )
     }
   </div>
 </a>
+
+<style>
+  .notebook-tags-row {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 0.5rem;
+    margin-top: 1rem;
+    min-height: 1.75rem;
+    overflow: hidden;
+    position: relative;
+  }
+
+  .notebook-tag-chip,
+  .notebook-tags-overflow {
+    flex: 0 0 auto;
+    max-width: 11rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .notebook-tag-chip[hidden],
+  .notebook-tags-overflow[hidden] {
+    display: none !important;
+  }
+</style>
+
+<script>
+  function fitNotebookCardTags() {
+    document.querySelectorAll<HTMLElement>(".notebook-tags-row").forEach((row) => {
+      const tags = Array.from(row.querySelectorAll<HTMLElement>("[data-tag-chip]"));
+      const overflow = row.querySelector<HTMLElement>("[data-tag-overflow]");
+      if (!overflow || tags.length === 0) return;
+
+      tags.forEach((tag) => { tag.hidden = false; });
+      overflow.hidden = false;
+      overflow.textContent = `+${tags.length}`;
+
+      const rowStyles = getComputedStyle(row);
+      const gap = Number.parseFloat(rowStyles.columnGap || rowStyles.gap || "0") || 0;
+      const availableWidth = row.clientWidth;
+      const overflowWidth = overflow.getBoundingClientRect().width;
+      const tagWidths = tags.map((tag) => tag.getBoundingClientRect().width);
+
+      let visibleCount = 0;
+      let usedWidth = 0;
+
+      for (let index = 0; index < tags.length; index += 1) {
+        const nextWidth = usedWidth + (visibleCount > 0 ? gap : 0) + tagWidths[index];
+        const remainingAfterThisTag = tags.length - index - 1;
+        const overflowReserve = remainingAfterThisTag > 0 ? gap + overflowWidth : 0;
+
+        if (nextWidth + overflowReserve > availableWidth) break;
+
+        visibleCount += 1;
+        usedWidth = nextWidth;
+      }
+
+      const hiddenTags = tags.slice(visibleCount);
+      tags.forEach((tag, index) => { tag.hidden = index >= visibleCount; });
+
+      if (hiddenTags.length > 0) {
+        overflow.textContent = `+${hiddenTags.length}`;
+        overflow.title = hiddenTags.map((tag) => tag.textContent?.trim()).filter(Boolean).join(", ");
+        overflow.hidden = false;
+      } else {
+        overflow.hidden = true;
+        overflow.removeAttribute("title");
+      }
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", fitNotebookCardTags, { once: true });
+  } else {
+    fitNotebookCardTags();
+  }
+
+  const tagRows = document.querySelectorAll<HTMLElement>(".notebook-tags-row");
+  if ("ResizeObserver" in window && tagRows.length > 0) {
+    const resizeObserver = new ResizeObserver(() => fitNotebookCardTags());
+    tagRows.forEach((row) => resizeObserver.observe(row));
+  }
+</script>

--- a/site/src/config.ts
+++ b/site/src/config.ts
@@ -17,6 +17,7 @@ export const SITE = {
   tagline: "Your cookbook for building AI with Microsoft Foundry.",
   description:
     "Forgebook is a Microsoft Foundry cookbook of runnable Jupyter notebook recipes, hands-on AI guides, and examples for building agents, model inference, and multimodal apps.",
+  repositoryUrl: REPO_URL,
   keywords: [
     "Microsoft Foundry",
     "Foundry cookbook",

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -121,8 +121,18 @@ const keywords = [...SITE.keywords, ...tags].join(", ");
     </main>
 
     <footer data-pagefind-ignore class="border-t border-subtle mt-16">
-      <div class="max-w-6xl mx-auto px-4 py-8 text-center text-muted text-sm">
+      <div class="max-w-6xl mx-auto px-4 py-8 text-center text-muted text-sm space-y-3">
         <p>Built with Astro • MIT License</p>
+        <nav class="flex flex-wrap justify-center gap-x-4 gap-y-2" aria-label="Footer">
+          <a class="hover:text-primary transition-colors" href={SITE.repositoryUrl}>GitHub</a>
+          <a class="hover:text-primary transition-colors" href={`${SITE.repositoryUrl}/blob/main/LICENSE`}>License</a>
+          <a class="hover:text-primary transition-colors" href={`${SITE.repositoryUrl}/blob/main/CODE_OF_CONDUCT.md`}>Code of Conduct</a>
+          <a class="hover:text-primary transition-colors" href={`${SITE.repositoryUrl}/blob/main/SECURITY.md`}>Security</a>
+          <a class="hover:text-primary transition-colors" href={`${SITE.repositoryUrl}/blob/main/SUPPORT.md`}>Support</a>
+          <a class="hover:text-primary transition-colors" href="https://privacy.microsoft.com/privacystatement">Privacy</a>
+          <a class="hover:text-primary transition-colors" href="https://www.microsoft.com/legal/terms-of-use">Terms of Use</a>
+          <a class="hover:text-primary transition-colors" href="https://www.microsoft.com/legal/intellectualproperty/trademarks">Trademarks</a>
+        </nav>
       </div>
     </footer>
 

--- a/site/src/lib/notebook.ts
+++ b/site/src/lib/notebook.ts
@@ -136,7 +136,7 @@ export interface NotebookCell {
 }
 
 /**
- * Rewrite relative image src paths so they resolve correctly on the published site.
+ * Rewrite relative asset paths so they resolve correctly on the published site.
  *
  * Notebook markdown cells use paths relative to the notebook file, e.g. `media/foo.png`.
  * On the site the page lives at `/base/notebook/<slug>/`, so the browser would wrongly
@@ -147,30 +147,147 @@ export interface NotebookCell {
  * leading `notebooks/` prefix, and prepend `<basePath>/notebook/` to build the correct
  * absolute URL.
  */
-function rewriteImagePaths(html: string, notebookPath: string, basePath: string): string {
+function rewriteAssetPaths(html: string, notebookPath: string, basePath: string): string {
   // Directory of the notebook relative to the repo root, e.g. "notebooks" or "notebooks/examples"
   const notebookDir = path.posix.dirname(notebookPath.replace(/\\/g, "/"));
 
   // Normalise basePath: ensure it has no trailing slash
   const base = basePath.replace(/\/$/, "");
 
-  return html.replace(
-    /(<img\b[^>]*\bsrc=["'])([^"']+)(["'])/gi,
+  const isAbsoluteOrSpecial = (url: string) => /^(https?:\/\/|\/|data:|#|mailto:|tel:|javascript:)/i.test(url);
+  const resolveAsset = (url: string): string => {
+    // Resolve relative to the notebook's directory, e.g.
+    //   notebookDir = "notebooks", src = "media/foo.png" → "notebooks/media/foo.png"
+    //   notebookDir = "notebooks/examples", src = "../media/foo.png" → "notebooks/media/foo.png"
+    const resolved = path.posix.normalize(path.posix.join(notebookDir, url));
+
+    // Strip leading "notebooks/" to get the path under public/notebook/
+    const underPublic = resolved.replace(/^notebooks\//, "");
+
+    return `${base}/notebook/${underPublic}`;
+  };
+
+  let result = html.replace(
+    /(<(?:img|video|audio|source|track)\b[^>]*\bsrc=["'])([^"']+)(["'])/gi,
     (_match, prefix: string, src: string, suffix: string) => {
       // Skip absolute URLs, data URIs, and protocol-relative URLs
-      if (/^(https?:\/\/|\/|data:|#)/.test(src)) return _match;
+      if (isAbsoluteOrSpecial(src)) return _match;
 
-      // Resolve relative to the notebook's directory, e.g.
-      //   notebookDir = "notebooks", src = "media/foo.png" → "notebooks/media/foo.png"
-      //   notebookDir = "notebooks/examples", src = "../media/foo.png" → "notebooks/media/foo.png"
-      const resolved = path.posix.normalize(path.posix.join(notebookDir, src));
-
-      // Strip leading "notebooks/" to get the path under public/notebook/
-      const underPublic = resolved.replace(/^notebooks\//, "");
-
-      return `${prefix}${base}/notebook/${underPublic}${suffix}`;
+      return `${prefix}${resolveAsset(src)}${suffix}`;
     }
   );
+
+  result = result.replace(
+    /(<a\b[^>]*\bhref=["'])([^"']+)(["'])/gi,
+    (_match, prefix: string, href: string, suffix: string) => {
+      // Only rewrite direct links to notebook assets. Other relative links are handled elsewhere.
+      if (isAbsoluteOrSpecial(href)) return _match;
+      if (!/\.(?:png|jpe?g|gif|webp|svg|mp4|webm|mov|mp3|wav|m4a|csv|json|jsonl|txt|pdf)(?:[?#].*)?$/i.test(href)) {
+        return _match;
+      }
+
+      return `${prefix}${resolveAsset(href)}${suffix}`;
+    }
+  );
+
+  return result;
+}
+
+const calloutTypes = {
+  note: {
+    title: "Note",
+    iconPath: "M12.002 1.999c5.523 0 10.001 4.478 10.001 10.002c0 5.523-4.478 10.001-10.001 10.001C6.478 22.002 2 17.524 2 12.001C2 6.477 6.478 1.999 12.002 1.999m0 1.5a8.502 8.502 0 1 0 0 17.003a8.502 8.502 0 0 0 0-17.003M12 10.5a.75.75 0 0 1 .75.75v5a.75.75 0 0 1-1.5 0v-5a.75.75 0 0 1 .75-.75M12 9a1 1 0 1 0 0-2a1 1 0 0 0 0 2",
+  },
+  tip: {
+    title: "Tip",
+    iconPath: "M12 2.001a7.25 7.25 0 0 1 7.25 7.25c0 2.096-.9 4.02-2.663 5.742a.75.75 0 0 0-.175.265l-.032.103l-1.13 4.895a2.25 2.25 0 0 1-2.02 1.737l-.173.007h-2.114a2.25 2.25 0 0 1-2.147-1.577l-.045-.167l-1.13-4.895a.75.75 0 0 0-.206-.368c-1.68-1.64-2.577-3.463-2.659-5.444l-.006-.298l.004-.24A7.25 7.25 0 0 1 12 2.002M14.115 18.5H9.884l.329 1.42a.75.75 0 0 0 .627.573l.103.008h2.114a.75.75 0 0 0 .7-.483l.03-.099zM12 3.501a5.75 5.75 0 0 0-5.746 5.53l-.004.22l.007.277c.076 1.563.8 3.02 2.206 4.392c.264.258.46.576.571.926l.049.178l.455 1.975h4.923l.458-1.976a2.25 2.25 0 0 1 .493-.97l.127-.133c1.404-1.373 2.128-2.828 2.204-4.392l.007-.277l-.004-.22A5.75 5.75 0 0 0 12 3.5",
+  },
+  important: {
+    title: "Important",
+    iconPath: "M12 2.002a3.875 3.875 0 0 0-3.875 3.875c0 2.92 1.207 6.552 1.813 8.199a2.19 2.19 0 0 0 2.064 1.423c.904 0 1.739-.542 2.063-1.418c.606-1.64 1.81-5.254 1.81-8.204A3.875 3.875 0 0 0 12 2.002M9.625 5.877a2.375 2.375 0 0 1 4.75 0c0 2.655-1.111 6.043-1.717 7.684a.69.69 0 0 1-.655.438a.69.69 0 0 1-.657-.44c-.607-1.652-1.721-5.058-1.721-7.682m2.376 11.124a2.501 2.501 0 1 0 0 5.002a2.501 2.501 0 0 0 0-5.002M11 19.502a1.001 1.001 0 1 1 2.002 0a1.001 1.001 0 0 1-2.002 0",
+  },
+  caution: {
+    title: "Caution",
+    iconPath: "M12 2c5.523 0 10 4.478 10 10s-4.477 10-10 10S2 17.522 2 12S6.477 2 12 2m0 1.667c-4.595 0-8.333 3.738-8.333 8.333S7.405 20.333 12 20.333s8.333-3.738 8.333-8.333S16.595 3.667 12 3.667m-.001 10.835a.999.999 0 1 1 0 1.998a.999.999 0 0 1 0-1.998M11.994 7a.75.75 0 0 1 .744.648l.007.101l.004 4.502a.75.75 0 0 1-1.493.103l-.007-.102l-.004-4.501a.75.75 0 0 1 .75-.751",
+  },
+  warning: {
+    title: "Warning",
+    iconPath: "M9.138 3.707c1.228-2.276 4.494-2.276 5.721 0l6.743 12.502c1.168 2.165-.4 4.792-2.86 4.793H5.255c-2.46 0-4.028-2.628-2.86-4.793zm4.4.712c-.66-1.225-2.419-1.225-3.08 0L3.715 16.921a1.75 1.75 0 0 0 1.54 2.581h13.487a1.75 1.75 0 0 0 1.54-2.581zM12 15a1 1 0 1 1 0 2a1 1 0 0 1 0-2m0-7.5a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0v-4.5A.75.75 0 0 1 12 7.5",
+  },
+} as const;
+
+type CalloutType = keyof typeof calloutTypes;
+
+/**
+ * Upgrade portable Markdown callouts into semantic, styleable HTML.
+ *
+ * Authors can write normal Jupyter-compatible Markdown like:
+ *
+ * > **Tip:** Keep the source image stable.
+ * > More supporting detail.
+ *
+ * In plain Markdown viewers this remains a blockquote. On Forgebook, the leading
+ * bold label becomes a callout title while the remaining paragraph text stays as body copy.
+ */
+function enhanceCallouts(html: string): string {
+  const template = dom.window.document.createElement("template");
+  template.innerHTML = html;
+  const svgNamespace = "http://www.w3.org/2000/svg";
+
+  template.content.querySelectorAll("blockquote").forEach((blockquote) => {
+    const firstParagraph = blockquote.querySelector(":scope > p");
+    const firstElement = firstParagraph?.firstElementChild;
+    if (!firstParagraph || !firstElement || !["STRONG", "B"].includes(firstElement.tagName)) {
+      return;
+    }
+
+    const label = firstElement.textContent?.trim().replace(/:$/, "").toLowerCase();
+    if (!label || !(label in calloutTypes)) {
+      return;
+    }
+
+    const type = label as CalloutType;
+    const { title, iconPath } = calloutTypes[type];
+
+    blockquote.classList.add("notebook-callout", `notebook-callout-${type}`);
+    blockquote.setAttribute("data-callout", type);
+    blockquote.setAttribute("aria-label", `${title} callout`);
+
+    const heading = dom.window.document.createElement("div");
+    heading.className = "notebook-callout-title";
+
+    const iconElement = dom.window.document.createElement("span");
+    iconElement.className = "notebook-callout-icon";
+    iconElement.setAttribute("aria-hidden", "true");
+
+    const iconSvg = dom.window.document.createElementNS(svgNamespace, "svg");
+    iconSvg.setAttribute("viewBox", "0 0 24 24");
+    iconSvg.setAttribute("fill", "none");
+    iconSvg.setAttribute("focusable", "false");
+
+    const iconPathElement = dom.window.document.createElementNS(svgNamespace, "path");
+    iconPathElement.setAttribute("fill", "currentColor");
+    iconPathElement.setAttribute("d", iconPath);
+    iconSvg.appendChild(iconPathElement);
+    iconElement.appendChild(iconSvg);
+
+    const titleElement = dom.window.document.createElement("strong");
+    titleElement.textContent = title;
+
+    heading.append(iconElement, titleElement);
+    blockquote.insertBefore(heading, firstParagraph);
+
+    firstElement.remove();
+    const firstNode = firstParagraph.firstChild;
+    if (firstNode?.nodeType === dom.window.Node.TEXT_NODE) {
+      firstNode.textContent = firstNode.textContent?.replace(/^\s+/, "") ?? "";
+    }
+    if (!firstParagraph.textContent?.trim() && firstParagraph.children.length === 0) {
+      firstParagraph.remove();
+    }
+  });
+
+  return template.innerHTML;
 }
 
 /**
@@ -216,8 +333,11 @@ export function renderNotebook(notebookJson: unknown, notebookPath: string, base
     // Restore preserved trusted iframes
     let result = restoreIframes(sanitized, currentIframes);
 
-    // Rewrite relative image paths to absolute URLs
-    result = rewriteImagePaths(result, notebookPath, basePath);
+    // Rewrite relative asset paths to absolute URLs
+    result = rewriteAssetPaths(result, notebookPath, basePath);
+
+    // Upgrade portable blockquote callouts to styled callout elements
+    result = enhanceCallouts(result);
 
     // Rewrite relative .ipynb links to site notebook pages
     return rewriteNotebookLinks(result, notebookPath, basePath);

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -119,24 +119,17 @@ function tagColor(tag: string): string {
       }
     </section>
 
-    <section class="bg-surface-elevated rounded-xl p-8 mt-12 border border-subtle">
+    <section class="mt-12">
       <h2
-        class="text-xl font-semibold text-primary mb-4"
+        class="text-2xl font-semibold text-primary mb-4"
       >
-        Quick Start
+        Start forging
       </h2>
-      <div class="space-y-4">
-        <div>
-          <h3 class="font-medium text-secondary mb-2">
-            Clone and run locally:
-          </h3>
-          <pre
-            class="bg-code text-code p-4 rounded-lg overflow-x-auto text-sm font-mono"><code>{`git clone ${REPO_URL}.git
+      <pre
+        class="bg-code text-code p-4 rounded-lg overflow-x-auto text-sm font-mono"><code>{`git clone ${REPO_URL}.git
 cd forgebook
 pip install -r requirements.txt
 jupyter notebook`}</code></pre>
-        </div>
-      </div>
     </section>
   </div>
 </BaseLayout>

--- a/site/src/pages/notebook/[slug]/index.astro
+++ b/site/src/pages/notebook/[slug]/index.astro
@@ -98,13 +98,27 @@ function tagColor(tag: string): string {
 
 <style is:global>
   .notebook-content pre {
-    background-color: rgb(15 23 42);
-    color: rgb(241 245 249);
+    background:
+      linear-gradient(180deg, color-mix(in srgb, var(--code-bg) 96%, #ffffff 4%), var(--code-bg));
+    color: var(--code-fg);
+    border: 1px solid var(--code-border);
+    box-shadow: inset 0 1px 0 color-mix(in srgb, #ffffff 60%, transparent);
     padding: 1rem;
-    border-radius: 0.5rem;
+    border-radius: 0.75rem;
     overflow-x: auto;
     font-size: 0.875rem;
+    line-height: 1.65;
     margin: 1rem 0;
+  }
+
+  .dark .notebook-content pre {
+    box-shadow: inset 0 1px 0 color-mix(in srgb, #ffffff 8%, transparent);
+  }
+
+  .notebook-content pre code {
+    color: inherit;
+    background: transparent;
+    text-shadow: none;
   }
 
   .notebook-content .code-block-wrapper pre {
@@ -133,6 +147,73 @@ function tagColor(tag: string): string {
       "Liberation Mono", monospace;
   }
 
+  .notebook-content :not(pre) > code {
+    background-color: var(--inline-code-bg);
+    color: var(--inline-code-fg);
+    border: 1px solid var(--inline-code-border);
+    border-radius: 0.35rem;
+    padding: 0.075rem 0.3rem;
+    font-size: 0.9em;
+  }
+
+  .notebook-content :not(pre) > code::before,
+  .notebook-content :not(pre) > code::after {
+    content: none;
+  }
+
+  .notebook-content .token.comment,
+  .notebook-content .token.prolog,
+  .notebook-content .token.doctype,
+  .notebook-content .token.cdata {
+    color: var(--code-token-comment);
+    font-style: italic;
+  }
+
+  .notebook-content .token.punctuation,
+  .notebook-content .token.operator {
+    color: var(--code-token-punctuation);
+  }
+
+  .notebook-content .token.property,
+  .notebook-content .token.tag,
+  .notebook-content .token.constant,
+  .notebook-content .token.symbol,
+  .notebook-content .token.deleted {
+    color: var(--code-token-property);
+  }
+
+  .notebook-content .token.boolean,
+  .notebook-content .token.number {
+    color: var(--code-token-number);
+  }
+
+  .notebook-content .token.selector,
+  .notebook-content .token.attr-name,
+  .notebook-content .token.string,
+  .notebook-content .token.char,
+  .notebook-content .token.builtin,
+  .notebook-content .token.inserted {
+    color: var(--code-token-string);
+  }
+
+  .notebook-content .token.keyword,
+  .notebook-content .token.atrule,
+  .notebook-content .token.attr-value {
+    color: var(--code-token-keyword);
+    font-weight: 600;
+  }
+
+  .notebook-content .token.function,
+  .notebook-content .token.class-name {
+    color: var(--code-token-function);
+  }
+
+  .notebook-content .token.regex,
+  .notebook-content .token.important,
+  .notebook-content .token.variable {
+    color: var(--code-token-variable);
+  }
+
   .notebook-content h1,
   .notebook-content h2,
   .notebook-content h3 {
@@ -159,6 +240,121 @@ function tagColor(tag: string): string {
   .notebook-content p {
     margin: 1rem 0;
     color: var(--neutral-fg-2);
+  }
+
+  .notebook-content blockquote.notebook-callout {
+    --callout-bg: #f7f7fb;
+    --callout-border: #8b8ca7;
+    --callout-title: #44445f;
+    --callout-text: var(--neutral-fg-1);
+    background-color: var(--callout-bg);
+    border: 1px solid color-mix(in srgb, var(--callout-border) 55%, transparent);
+    border-left: 0.25rem solid var(--callout-border);
+    border-radius: 0.75rem;
+    color: var(--callout-text);
+    font-style: normal;
+    font-weight: 400;
+    margin: 1.5rem 0;
+    padding: 1rem 1.15rem;
+    quotes: none;
+  }
+
+  .notebook-content blockquote.notebook-callout[data-callout="note"] {
+    --callout-bg: #f4ebff;
+    --callout-border: #7c3aed;
+    --callout-title: #5b21b6;
+  }
+
+  .notebook-content blockquote.notebook-callout[data-callout="tip"] {
+    --callout-bg: #eef8ef;
+    --callout-border: #1f9d3a;
+    --callout-title: #12722a;
+  }
+
+  .notebook-content blockquote.notebook-callout[data-callout="important"] {
+    --callout-bg: #eaf3ff;
+    --callout-border: #2563eb;
+    --callout-title: #1d4ed8;
+  }
+
+  .notebook-content blockquote.notebook-callout[data-callout="caution"] {
+    --callout-bg: #fff1f2;
+    --callout-border: #dc2626;
+    --callout-title: #b91c1c;
+  }
+
+  .notebook-content blockquote.notebook-callout[data-callout="warning"] {
+    --callout-bg: #fff7ed;
+    --callout-border: #ea580c;
+    --callout-title: #c2410c;
+  }
+
+  .dark .notebook-content blockquote.notebook-callout[data-callout="note"] {
+    --callout-bg: #2b2142;
+    --callout-border: #a78bfa;
+    --callout-title: #ddd6fe;
+  }
+
+  .dark .notebook-content blockquote.notebook-callout[data-callout="tip"] {
+    --callout-bg: #132d1a;
+    --callout-border: #4ade80;
+    --callout-title: #bbf7d0;
+  }
+
+  .dark .notebook-content blockquote.notebook-callout[data-callout="important"] {
+    --callout-bg: #14253f;
+    --callout-border: #60a5fa;
+    --callout-title: #bfdbfe;
+  }
+
+  .dark .notebook-content blockquote.notebook-callout[data-callout="caution"] {
+    --callout-bg: #3a1719;
+    --callout-border: #f87171;
+    --callout-title: #fecaca;
+  }
+
+  .dark .notebook-content blockquote.notebook-callout[data-callout="warning"] {
+    --callout-bg: #341f10;
+    --callout-border: #fb923c;
+    --callout-title: #fed7aa;
+  }
+
+  .notebook-content .notebook-callout-title {
+    align-items: center;
+    color: var(--callout-title);
+    display: flex;
+    gap: 0.5rem;
+    font-size: 0.95rem;
+    font-weight: 700;
+    line-height: 1.3;
+    margin-bottom: 0.65rem;
+  }
+
+  .notebook-content .notebook-callout-icon {
+    align-items: center;
+    display: inline-flex;
+    height: 1.25rem;
+    justify-content: center;
+    width: 1.25rem;
+  }
+
+  .notebook-content .notebook-callout-icon svg {
+    display: block;
+    height: 1.25rem;
+    width: 1.25rem;
+  }
+
+  .notebook-content blockquote.notebook-callout p {
+    color: var(--callout-text);
+    margin: 0.65rem 0 0;
+  }
+
+  .notebook-content blockquote.notebook-callout p:first-of-type {
+    margin-top: 0;
+  }
+
+  .notebook-content blockquote.notebook-callout code {
+    font-style: normal;
   }
 
   @media (max-width: 640px) {

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -48,8 +48,20 @@
   --accent-brand-pressed: #444791; /* Fluent brand purple - pressed */
   
   /* Code block colors */
-  --code-bg: #1e293b;           /* Dark slate for code */
-  --code-fg: #f1f5f9;           /* Light text for code */
+  --code-bg: #f6f7f9;           /* Light greyscale code surface */
+  --code-fg: #1f2937;           /* Dark text for code */
+  --code-border: #d9dee7;
+  --inline-code-bg: #f3f4f6;
+  --inline-code-fg: #374151;
+  --inline-code-border: #e5e7eb;
+  --code-token-comment: #6b7280;
+  --code-token-punctuation: #4b5563;
+  --code-token-property: #9f1239;
+  --code-token-number: #9a3412;
+  --code-token-string: #166534;
+  --code-token-keyword: #1d4ed8;
+  --code-token-function: #7c3aed;
+  --code-token-variable: #0f766e;
   
   /* Font stacks as CSS variables for body */
   --font-stack-sans: "Segoe UI", "Segoe UI Variable", -apple-system, BlinkMacSystemFont,
@@ -77,6 +89,18 @@
   /* Code block colors - slightly different in dark mode */
   --code-bg: #0f172a;           /* Darker slate for code */
   --code-fg: #f1f5f9;           /* Light text for code */
+  --code-border: #243044;
+  --inline-code-bg: #1f2937;
+  --inline-code-fg: #e5e7eb;
+  --inline-code-border: #374151;
+  --code-token-comment: #94a3b8;
+  --code-token-punctuation: #cbd5e1;
+  --code-token-property: #fda4af;
+  --code-token-number: #fdba74;
+  --code-token-string: #86efac;
+  --code-token-keyword: #93c5fd;
+  --code-token-function: #c4b5fd;
+  --code-token-variable: #5eead4;
 }
 
 /* ============================================

--- a/site/tests/navigation.spec.ts
+++ b/site/tests/navigation.spec.ts
@@ -17,11 +17,40 @@ test.describe("Site Navigation", () => {
     await expect(page.getByRole("heading", { name: "Create Your First Agent (Part 1)", level: 1 })).toBeVisible();
   });
 
+  test("notebook card tags stay on one row", async ({ page }) => {
+    await page.goto(HOME);
+
+    const rows = page.locator(".notebook-tags-row");
+    await expect(rows.first()).toBeVisible();
+
+    const wrappedRows = await rows.evaluateAll((elements) =>
+      elements
+        .map((row) => {
+          const visibleChildren = Array.from(row.children).filter(
+            (child) => !(child as HTMLElement).hidden,
+          );
+          const lineTops = new Set(
+            visibleChildren.map((child) => Math.round(child.getBoundingClientRect().top)),
+          );
+          return {
+            text: visibleChildren.map((child) => child.textContent?.trim()).join(" "),
+            lineCount: lineTops.size,
+          };
+        })
+        .filter((row) => row.lineCount > 1),
+    );
+
+    expect(wrappedRows).toEqual([]);
+  });
+
   test("notebook page has action buttons", async ({ page }) => {
     await page.goto(NOTEBOOK);
     await expect(page.getByRole("link", { name: "Open in GitHub" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Copy Markdown" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Open options" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Copy page" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Markdown options" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Share", exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Share options" })).toBeVisible();
   });
 
   test("header navigation works", async ({ page }) => {
@@ -32,7 +61,21 @@ test.describe("Site Navigation", () => {
 
   test("GitHub link points to correct repo", async ({ page }) => {
     await page.goto(HOME);
-    const githubLink = page.getByRole("link", { name: "GitHub" });
+    const githubLink = page.getByRole("link", { name: "View on GitHub" });
     await expect(githubLink).toHaveAttribute("href", "https://github.com/microsoft-foundry/forgebook");
+  });
+
+  test("footer exposes public repository and legal links", async ({ page }) => {
+    await page.goto(HOME);
+
+    const footer = page.locator("footer");
+    await expect(footer.getByRole("link", { name: "GitHub" })).toHaveAttribute("href", "https://github.com/microsoft-foundry/forgebook");
+    await expect(footer.getByRole("link", { name: "License" })).toHaveAttribute("href", "https://github.com/microsoft-foundry/forgebook/blob/main/LICENSE");
+    await expect(footer.getByRole("link", { name: "Code of Conduct" })).toHaveAttribute("href", "https://github.com/microsoft-foundry/forgebook/blob/main/CODE_OF_CONDUCT.md");
+    await expect(footer.getByRole("link", { name: "Security" })).toHaveAttribute("href", "https://github.com/microsoft-foundry/forgebook/blob/main/SECURITY.md");
+    await expect(footer.getByRole("link", { name: "Support" })).toHaveAttribute("href", "https://github.com/microsoft-foundry/forgebook/blob/main/SUPPORT.md");
+    await expect(footer.getByRole("link", { name: "Privacy" })).toHaveAttribute("href", "https://privacy.microsoft.com/privacystatement");
+    await expect(footer.getByRole("link", { name: "Terms of Use" })).toHaveAttribute("href", "https://www.microsoft.com/legal/terms-of-use");
+    await expect(footer.getByRole("link", { name: "Trademarks" })).toHaveAttribute("href", "https://www.microsoft.com/legal/intellectualproperty/trademarks");
   });
 });

--- a/site/tests/notebook-callouts.spec.ts
+++ b/site/tests/notebook-callouts.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "@playwright/test";
+
+const NOTEBOOK = "/forgebook/notebook/sora-video-generation-rest-api";
+
+test.describe("Notebook Callouts", () => {
+  test("portable Tip blockquote renders as a styled callout", async ({ page }) => {
+    await page.goto(NOTEBOOK);
+
+    const callout = page.locator('.notebook-content blockquote.notebook-callout[data-callout="tip"]').first();
+    await expect(callout).toBeVisible();
+    await expect(callout.locator(".notebook-callout-title")).toHaveText(/Tip/);
+    await expect(callout).toContainText("If you do not have a source image yet");
+    await expect(callout.locator("p").first()).not.toContainText(/^Tip:/);
+  });
+});

--- a/site/tests/notebook-images.spec.ts
+++ b/site/tests/notebook-images.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 
 const NOTEBOOK = "/forgebook/notebook/foundry-agent-part-1";
+const VIDEO_NOTEBOOK = "/forgebook/notebook/sora-video-generation-rest-api";
 
 test.describe("Notebook Images", () => {
   test("all images on notebook page have absolute src paths", async ({ page }) => {
@@ -41,6 +42,45 @@ test.describe("Notebook Images", () => {
     for (const url of urls) {
       const response = await page.request.get(url);
       expect(response.status(), `Broken image: ${url}`).toBe(200);
+    }
+  });
+
+  test("notebook media sources use absolute paths", async ({ page }) => {
+    await page.goto(VIDEO_NOTEBOOK);
+
+    const media = page.locator(".notebook-content video, .notebook-content audio, .notebook-content source, .notebook-content track");
+    const count = await media.count();
+    expect(count).toBeGreaterThan(0);
+
+    for (let i = 0; i < count; i++) {
+      const src = await media.nth(i).getAttribute("src");
+      if (!src) continue;
+
+      expect(
+        src.startsWith("/") || src.startsWith("data:") || src.startsWith("http"),
+        `Media ${i} has relative src: ${src}`,
+      ).toBe(true);
+    }
+  });
+
+  test("notebook media sources return 200", async ({ page }) => {
+    await page.goto(VIDEO_NOTEBOOK);
+
+    const media = page.locator(".notebook-content video, .notebook-content audio, .notebook-content source, .notebook-content track");
+    const count = await media.count();
+    expect(count).toBeGreaterThan(0);
+
+    const urls = new Set<string>();
+    for (let i = 0; i < count; i++) {
+      const src = await media.nth(i).getAttribute("src");
+      if (src && !src.startsWith("data:")) {
+        urls.add(new URL(src, page.url()).href);
+      }
+    }
+
+    for (const url of urls) {
+      const response = await page.request.get(url);
+      expect(response.status(), `Broken media: ${url}`).toBe(200);
     }
   });
 });

--- a/site/tests/telemetry.spec.ts
+++ b/site/tests/telemetry.spec.ts
@@ -301,7 +301,7 @@ test.describe("Telemetry", () => {
     const captured = await setupCapture(page);
     await page.goto(NOTEBOOK);
 
-    await page.getByRole("button", { name: "Copy Markdown" }).click();
+    await page.getByRole("button", { name: "Copy page" }).click();
     await page.waitForTimeout(1000); // Wait for fetch + clipboard write
     await flush(page);
 
@@ -313,13 +313,32 @@ test.describe("Telemetry", () => {
   // --------------------------------------------------
   // 11. Share — copy link
   // --------------------------------------------------
+  test("primary share button copies link and fires ShareAction event", async ({ page, context }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    const captured = await setupCapture(page);
+    await page.goto(NOTEBOOK);
+
+    await page.getByRole("button", { name: "Share", exact: true }).click();
+    await expect(page.locator("#share-btn-text")).toHaveText("Copied!");
+    await expect(page.locator("#share-dropdown")).toHaveClass(/hidden/);
+    await page.waitForTimeout(1000);
+    await flush(page);
+
+    const events = findEvents(captured, "ShareAction");
+    const copyEvent = events.find((e) =>
+      e.data?.baseData?.properties?.method === "CopyLink" &&
+      e.data?.baseData?.properties?.source === "button"
+    );
+    expect(copyEvent).toBeTruthy();
+  });
+
   test("share copy-link fires ShareAction event", async ({ page, context }) => {
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);
     const captured = await setupCapture(page);
     await page.goto(NOTEBOOK);
 
     // Open share dropdown
-    await page.locator("#share-btn").click();
+    await page.locator("#share-dropdown-btn").click();
     await page.waitForSelector("#share-dropdown:not(.hidden)", { timeout: 2000 });
 
     // Click "Copy Link" and wait for async clipboard operation
@@ -340,7 +359,7 @@ test.describe("Telemetry", () => {
     await page.goto(NOTEBOOK);
 
     // Open share dropdown
-    await page.locator("#share-btn").click();
+    await page.locator("#share-dropdown-btn").click();
     await page.waitForSelector("#share-dropdown:not(.hidden)", { timeout: 2000 });
 
     // Prevent navigation to X


### PR DESCRIPTION
## Summary

- Improve recipe-page code block rendering with light-mode greyscale and Prism token colors
- Fix inline code pseudo-backticks from Tailwind Typography
- Rewrite notebook asset paths for video/audio/source/track and direct asset links
- Add portable blockquote callout rendering with Fluent icons
- Refine recipe page action buttons and homepage card tag rows
- Add public open-source footer links and Code of Conduct
- Flatten homepage Start forging section

## Follow-up issues

- #28 Accessibility review for public Forgebook site
- #29 Web compliance and cookie review for GitHub Pages
- #30 Define public site ownership and security/compliance operating model
- #31 SEO, marketing analytics, and launch readiness for Forgebook

## Validation

- npm run build
- npx playwright test tests/navigation.spec.ts --project=desktop
- npx playwright test tests/notebook-images.spec.ts --project=desktop
- npx playwright test tests/notebook-callouts.spec.ts --project=desktop
- PUBLIC_APP_INSIGHTS_CONNECTION_STRING=... npm run build && npx playwright test tests/telemetry.spec.ts --project=desktop --grep "copying markdown|primary share button|share copy-link|share on X"
