### PR TITLE
chore(registry): normalize pre-Jun-2 dates to 2026-06-02 (launch date)

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -107,7 +107,7 @@
   path: notebooks/mastering-foundry-iq.ipynb
   title: "Mastering Foundry IQ"
   description: "End-to-end Foundry IQ walkthrough: every Knowledge Source type, one unified Knowledge Base, and integrations with Foundry Agent Service and Microsoft Agent Framework."
-  date: "2026-05-27"
+  date: "2026-06-02"
   authors:
     - github: farzad528
   tags:
@@ -124,7 +124,7 @@
   path: notebooks/mai-transcribe-1-5.ipynb
   title: "Build Speech-to-Text with MAI-Transcribe-1.5"
   description: "Speech API multipart cookbook for MAI-Transcribe-1.5 covering baseline transcription, verbatim mode, phrase-list entity biasing, and language identification."
-  date: "2026-05-28"
+  date: "2026-06-02"
   authors:
     - github: anihitk07
   tags:
@@ -137,7 +137,7 @@
   path: notebooks/mai-voice-2.ipynb
   title: "Build Multilingual TTS with MAI-Voice-2-Preview"
   description: "MAI-Voice-2-Preview notebook with REST calls, multilingual prebuilt voices, gated voice-prompting guidance, and model-card-aligned preview notes."
-  date: "2026-05-28"
+  date: "2026-06-02"
   authors:
     - github: anihitk07
   tags:
@@ -150,7 +150,7 @@
   path: notebooks/mai-image-2-5.ipynb
   title: "Build a Production Editing Recipe with MAI-Image-2.5"
   description: "Private-preview MAI-Image-2.5 notebook covering text-to-image generation, image edits, safety reminders, and troubleshooting."
-  date: "2026-05-28"
+  date: "2026-06-02"
   authors:
     - github: anihitk07
   tags:
@@ -163,7 +163,7 @@
   path: notebooks/sora-video-generation-rest-api.ipynb
   title: "Guide Sora 2 with Images and Audio"
   description: "Use Azure OpenAI REST calls to generate a Sora 2 clip, reuse a frame as an image reference, and add ambient audio."
-  date: "2026-05-27"
+  date: "2026-06-02"
   authors:
     - github: nicholasdbrady
   tags:
@@ -178,7 +178,7 @@
   path: notebooks/microsoft-iq-in-foundry.ipynb
   title: "Microsoft IQ in Foundry"
   description: "Build your own knowledge layer in Foundry IQ: start with your own files (zero setup), then layer in Web IQ, Work IQ, and Fabric IQ, and query every source with one call."
-  date: "2026-05-29"
+  date: "2026-06-02"
   authors:
     - github: farzad528
   tags:


### PR DESCRIPTION
## Hygiene fix

The Forgebook cookbook went public on **2026-06-02**, but six existing registry entries carry pre-launch dates (2026-05-27 through 2026-05-29) reflecting when authors *worked* on the recipes — not when readers could actually find them.

Backdating every pre-launch entry to `2026-06-02` so the homepage **Latest** ordering reflects public availability, not internal authoring history.

### Affected entries

| Slug | From | To |
|---|---|---|
| mastering-foundry-iq | 2026-05-27 | 2026-06-02 |
| mai-transcribe-1-5 | 2026-05-28 | 2026-06-02 |
| mai-voice-2 | 2026-05-28 | 2026-06-02 |
| mai-image-2-5 | 2026-05-28 | 2026-06-02 |
| sora-video-generation-rest-api | 2026-05-27 | 2026-06-02 |
| microsoft-iq-in-foundry | 2026-05-29 | 2026-06-02 |

### Validation

- `npx tsx validate-registry.ts` → 13 notebooks ✅
- Registry-only change; no notebook content modified.