### PR TITLE
Improve mobile recipe list layout

### DIFF
--- a/site/src/components/NotebookCard.astro
+++ b/site/src/components/NotebookCard.astro
@@ -207,7 +207,10 @@ const formattedPopularity = hasPopularityCount ? formatCount(popularityCount) : 
       overflow.hidden = false;
       overflow.textContent = `+${tags.length}`;
 
-      if (row.closest(".notebooks-collection.list-view")) {
+      const isListView = row.closest(".notebooks-collection.list-view");
+      const isMobileListView = isListView && window.matchMedia("(max-width: 639px)").matches;
+
+      if (isListView && !isMobileListView) {
         const visibleCount = Math.min(2, tags.length);
         const hiddenTags = tags.slice(visibleCount);
         tags.forEach((tag, index) => { tag.hidden = index >= visibleCount; });

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -549,6 +549,7 @@ jupyter notebook`}</code></pre>
 
   .notebooks-collection.list-view :global(.notebook-card-meta) {
     display: block;
+    justify-self: start;
   }
 
   .notebooks-collection.list-view :global(.notebook-tags-row) {
@@ -900,12 +901,28 @@ jupyter notebook`}</code></pre>
     }
 
     .notebooks-collection.list-view :global(.notebook-card) {
-      gap: 0.75rem;
+      align-items: flex-start;
+      flex-wrap: wrap;
+      gap: 0.75rem 1rem;
+    }
+
+    .notebooks-collection.list-view :global(.notebook-card-main) {
+      flex-basis: 100%;
+    }
+
+    .notebooks-collection.list-view :global(.notebook-card-title) {
+      display: -webkit-box;
+      overflow: hidden;
+      text-overflow: clip;
+      white-space: normal;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
     }
 
     .notebooks-collection.list-view :global(.notebook-card-footer) {
-      flex-basis: min(18rem, 45vw);
-      grid-template-columns: 5.5rem minmax(0, 1fr);
+      flex: 1 1 100%;
+      grid-template-columns: auto minmax(0, 1fr);
+      width: 100%;
     }
   }
 


### PR DESCRIPTION
## Summary
- Stack mobile list cards so titles have room to wrap cleanly
- Keep list-view tags on one row with measured `+#` overflow behavior
- Keep dates left-aligned and tags right-aligned in list metadata

## Validation
- `cd site && npm run build`