### PR TITLE
Prerequisites update to include searchable property settings

### DIFF
--- a/notebooks/azure-ai-search-custom-schema-citations.ipynb
+++ b/notebooks/azure-ai-search-custom-schema-citations.ipynb
@@ -41,6 +41,7 @@
     "|---|---|\n",
     "| Microsoft Foundry project | A project endpoint and one chat deployment (e.g. `gpt-4.1`) |\n",
     "| Azure AI Search | An existing index, connected to the project as a `CognitiveSearch` connection |\n",
+    "| Index field attributes | The fields you map to `url` and `title` must be **retrievable** and **searchable** in the index definition, or they won't appear in citation annotations |\n",
     "| Identity | `az login` — the notebook uses `DefaultAzureCredential` |\n",
     "\n",
     "You do **not** need to re-index or rename any fields. This recipe works against the schema you\n",


### PR DESCRIPTION
## Summary

Adds a note to the Azure AI Search custom schema citations notebook documenting the field attribute requirements for citation annotations.

## Why

When using custom Azure AI Search schemas, citation annotations may not include URL and title metadata unless the corresponding fields are configured with the appropriate index attributes.

This clarification is based on validation performed while testing the notebook against a custom schema and should help users avoid a common source of missing citation metadata.

## Changes

* Updated the Prerequisites section to clarify that the fields mapped to `url` and `title` must be configured as both **retrievable** and **searchable** in the Azure AI Search index definition. Without these attributes, the corresponding metadata may not be returned in citation annotations when using custom schemas.
