### PR TITLE
Use production page views for popular recipes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,8 @@ cd site && npm run build                      # Full build with type checking
 - Two groups: Core Capabilities (agents, inference, evaluation, etc.) and Integrations (langchain, mcp, etc.)
 
 ### Popular Notebooks
-- `site/src/data/popular.json` is refreshed by `deploy.yml` (on every push to `main`, on the daily 06:00 UTC cron, and on manual dispatch) by querying App Insights click data via OIDC.
+- `site/src/data/popular.json` is refreshed by `deploy.yml` (on every push to `main`, on the daily 06:00 UTC cron, and on manual dispatch) by querying production recipe page views via App Insights and OIDC.
+- The carousel ranks current registry recipes by trailing-30-day views while each badge displays production views since the 2026-06-02 launch.
 - The committed copy is a fallback: if the App Insights query fails, the build logs a warning and reuses the last good `popular.json` so the deploy never breaks on a transient telemetry outage.
 - **Never edit popular.json manually** — it gets overwritten on the next deploy.
 - Homepage shows "Most Popular" section only when ≥12 recipes exist

--- a/scripts/fetch-popular.ts
+++ b/scripts/fetch-popular.ts
@@ -1,5 +1,5 @@
 /**
- * Queries Azure Application Insights for the most-clicked notebook cards
+ * Queries Azure Application Insights for the most-viewed production recipes
  * and writes the results to site/src/data/popular.json.
  *
  * Uses Azure AD (Entra ID) authentication via DefaultAzureCredential,
@@ -11,54 +11,77 @@
  *                               e.g. /subscriptions/{sub}/resourceGroups/{rg}/providers/microsoft.insights/components/{name}
  *
  * Optional:
- *   POPULAR_DAYS   — Lookback window in days (default: 30)
- *   POPULAR_LIMIT  — Max notebooks to include (default: 6)
+ *   POPULAR_DAYS        — Ranking window in days (default: 30)
+ *   POPULAR_LIMIT       — Max notebooks to include (default: 6)
+ *   POPULAR_SINCE       — Inclusive UTC view-count start (default: 2026-06-02T00:00:00Z)
+ *   POPULAR_HOST        — Production hostname (default: microsoft-foundry.github.io)
+ *   POPULAR_BASE_PATH   — Production site base path (default: /forgebook)
  */
 
-import { writeFileSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { DefaultAzureCredential } from "@azure/identity";
 import { LogsQueryClient } from "@azure/monitor-query-logs";
+import yaml from "yaml";
 
 interface PopularEntry {
   slug: string;
-  clicks: number;
+  views: number;
+  recentViews: number;
+}
+
+interface RegistryEntry {
+  slug: string;
 }
 
 const RESOURCE_ID = process.env.APP_INSIGHTS_RESOURCE_ID;
 const DAYS = Number(process.env.POPULAR_DAYS) || 30;
 const LIMIT = Number(process.env.POPULAR_LIMIT) || 6;
+const SINCE = process.env.POPULAR_SINCE || "2026-06-02T00:00:00Z";
+const HOST = process.env.POPULAR_HOST || "microsoft-foundry.github.io";
+const BASE_PATH = (process.env.POPULAR_BASE_PATH || "/forgebook").replace(/\/+$/, "");
 
 const OUTPUT_PATH = resolve(
   import.meta.dirname ?? ".",
   "../site/src/data/popular.json"
 );
+const REGISTRY_PATH = resolve(import.meta.dirname ?? ".", "../registry.yaml");
 
+const registry = yaml.parse(readFileSync(REGISTRY_PATH, "utf-8")) as RegistryEntry[];
+const publishedSlugs = registry.map(({ slug }) => slug);
+const kustoSlugs = JSON.stringify(publishedSlugs);
+const recipePathPattern = `^${BASE_PATH.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/notebook/([^/]+)/?$`;
 const query = `
-customEvents
-| where timestamp > ago(${DAYS}d)
-| where name == "Click"
-| where tostring(customDimensions.label) startswith "notebook-card:"
-| extend slug = replace_string(tostring(customDimensions.label), "notebook-card:", "")
-| summarize clicks = count() by slug
-| order by clicks desc
+let publishedSlugs = dynamic(${kustoSlugs});
+pageViews
+| where timestamp >= datetime(${SINCE})
+| extend parsedUrl = parse_url(tostring(url))
+| extend host = tolower(tostring(parsedUrl.Host)), path = tostring(parsedUrl.Path)
+| where host == "${HOST.toLowerCase()}"
+| extend slug = extract(@"${recipePathPattern}", 1, path)
+| where isnotempty(slug) and slug in (publishedSlugs)
+| summarize sinceLaunchViews = count(), recentViews = countif(timestamp > ago(${DAYS}d)) by slug
+| where recentViews > 0
+| order by recentViews desc, sinceLaunchViews desc, slug asc
 | take ${LIMIT}
 `;
 
 async function main(): Promise<void> {
   if (!RESOURCE_ID) {
-    console.warn(
-      "[fetch-popular] APP_INSIGHTS_RESOURCE_ID not set — writing empty popular.json."
-    );
-    writeOutput({ updatedAt: new Date().toISOString(), notebooks: [] });
-    return;
+    throw new Error("APP_INSIGHTS_RESOURCE_ID is required");
   }
 
+  const sinceDate = new Date(SINCE);
+  if (Number.isNaN(sinceDate.getTime())) {
+    throw new Error(`POPULAR_SINCE must be an ISO 8601 timestamp: ${SINCE}`);
+  }
+
+  const queryDays = Math.max(DAYS, Math.ceil((Date.now() - sinceDate.getTime()) / 86_400_000) + 1);
   const credential = new DefaultAzureCredential();
   const client = new LogsQueryClient(credential);
 
   const result = await client.queryResource(RESOURCE_ID, query, {
-    duration: `P${DAYS}D`,
+    duration: `P${queryDays}D`,
   });
 
   if (result.status !== "Success") {
@@ -70,18 +93,28 @@ async function main(): Promise<void> {
   const rows = result.tables[0]?.rows ?? [];
   const notebooks: PopularEntry[] = rows.map((row) => ({
     slug: row[0] as string,
-    clicks: row[1] as number,
+    views: row[1] as number,
+    recentViews: row[2] as number,
   }));
 
   console.log(
-    `[fetch-popular] Found ${notebooks.length} popular notebooks (last ${DAYS} days).`
+    `[fetch-popular] Found ${notebooks.length} popular recipes ranked by the last ${DAYS} days.`
   );
 
-  writeOutput({ updatedAt: new Date().toISOString(), notebooks });
+  writeOutput({
+    metricVersion: "recipe-page-views-v1",
+    updatedAt: new Date().toISOString(),
+    since: sinceDate.toISOString(),
+    rankingWindowDays: DAYS,
+    notebooks,
+  });
 }
 
 function writeOutput(payload: {
+  metricVersion: "recipe-page-views-v1";
   updatedAt: string;
+  since: string;
+  rankingWindowDays: number;
   notebooks: PopularEntry[];
 }): void {
   mkdirSync(dirname(OUTPUT_PATH), { recursive: true });

--- a/site/src/components/NotebookCard.astro
+++ b/site/src/components/NotebookCard.astro
@@ -17,11 +17,11 @@ interface NotebookEntry {
 
 interface Props {
   notebook: NotebookEntry;
-  popularityCount?: number;
+  viewCount?: number;
 }
 
-const { notebook, popularityCount } = Astro.props;
-const hasPopularityCount = typeof popularityCount === "number";
+const { notebook, viewCount } = Astro.props;
+const hasViewCount = typeof viewCount === "number";
 
 function tagColor(tag: string): string {
   const hash = [...tag].reduce((h, c) => ((h << 5) - h + c.charCodeAt(0)) | 0, 0);
@@ -36,7 +36,7 @@ function formatCount(count: number): string {
   return count.toString();
 }
 
-const formattedPopularity = hasPopularityCount ? formatCount(popularityCount) : "";
+const formattedViewCount = hasViewCount ? formatCount(viewCount) : "";
 ---
 
 <a
@@ -54,16 +54,16 @@ const formattedPopularity = hasPopularityCount ? formatCount(popularityCount) : 
         {notebook.title}
       </h3>
       {
-        hasPopularityCount && (
+        hasViewCount && (
           <span
             class="notebook-popularity"
-            aria-label={`${formattedPopularity} popularity clicks`}
-            title={`${formattedPopularity} popularity clicks`}
+            aria-label={`${formattedViewCount} views`}
+            title={`${formattedViewCount} views`}
           >
             <svg viewBox="0 0 24 24" aria-hidden="true">
               <path d="M12 5.25c5.1 0 8.3 4.25 9.36 6.04a1.4 1.4 0 0 1 0 1.42c-1.06 1.79-4.26 6.04-9.36 6.04s-8.3-4.25-9.36-6.04a1.4 1.4 0 0 1 0-1.42c1.06-1.79 4.26-6.04 9.36-6.04Zm0 2c-4 0-6.67 3.2-7.64 4.75.97 1.55 3.64 4.75 7.64 4.75s6.67-3.2 7.64-4.75C18.67 10.45 16 7.25 12 7.25Zm0 1.5a3.25 3.25 0 1 1 0 6.5 3.25 3.25 0 0 1 0-6.5Zm0 2a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5Z" fill="currentColor" />
             </svg>
-            <span>{formattedPopularity}</span>
+            <span>{formattedViewCount}</span>
           </span>
         )
       }

--- a/site/src/data/popular.json
+++ b/site/src/data/popular.json
@@ -1,21 +1,38 @@
 {
-  "updatedAt": "2026-05-27T07:31:43.739Z",
+  "metricVersion": "recipe-page-views-v1",
+  "updatedAt": "2026-07-16T17:10:07.405Z",
+  "since": "2026-06-02T00:00:00.000Z",
+  "rankingWindowDays": 30,
   "notebooks": [
     {
+      "slug": "mastering-foundry-iq",
+      "views": 2197,
+      "recentViews": 1029
+    },
+    {
+      "slug": "microsoft-iq-in-foundry",
+      "views": 383,
+      "recentViews": 302
+    },
+    {
+      "slug": "mai-voice-2",
+      "views": 824,
+      "recentViews": 279
+    },
+    {
+      "slug": "mai-transcribe-1-5",
+      "views": 687,
+      "recentViews": 209
+    },
+    {
       "slug": "foundry-agent-part-1",
-      "clicks": 19
+      "views": 170,
+      "recentViews": 98
     },
     {
-      "slug": "mai-voice-1-foundry",
-      "clicks": 2
-    },
-    {
-      "slug": "mai-image-2-foundry",
-      "clicks": 2
-    },
-    {
-      "slug": "mai-transcribe-1-foundry",
-      "clicks": 1
+      "slug": "migrate-oyd-to-foundry-iq",
+      "views": 92,
+      "recentViews": 92
     }
   ]
 }

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -8,11 +8,14 @@ import { buildHomeSchema } from "@/lib/schema";
 import popularRaw from "@/data/popular.json";
 
 interface PopularData {
+  metricVersion: "recipe-page-views-v1";
   updatedAt: string;
-  notebooks: { slug: string; clicks: number }[];
+  since: string;
+  rankingWindowDays: number;
+  notebooks: { slug: string; views: number; recentViews: number }[];
 }
 const popularData = popularRaw as PopularData;
-const popularityBySlug = new Map(popularData.notebooks.map((popular) => [popular.slug, popular.clicks]));
+const viewsBySlug = new Map(popularData.notebooks.map((popular) => [popular.slug, popular.views]));
 
 const notebooksCollection = await getCollection("notebooks");
 
@@ -29,16 +32,16 @@ const notebooks = notebooksCollection.map((entry) => ({
 
 // Build the "Popular" carousel from analytics-backed entries only.
 type NotebookSummary = (typeof notebooks)[number];
-type PopularNotebook = NotebookSummary & { popularityCount: number };
+type PopularNotebook = NotebookSummary & { viewCount: number };
 const notebookBySlug = new Map(notebooks.map((n) => [n.slug, n]));
 const popularNotebooks = [...popularData.notebooks]
-  .sort((a, b) => b.clicks - a.clicks)
+  .sort((a, b) => b.recentViews - a.recentViews)
   .slice(0, 6)
   .map((popular) => {
     const notebook = notebookBySlug.get(popular.slug);
     if (!notebook) return undefined;
 
-    return { ...notebook, popularityCount: popular.clicks };
+    return { ...notebook, viewCount: popular.views };
   })
   .filter((notebook): notebook is PopularNotebook => Boolean(notebook));
 
@@ -83,7 +86,7 @@ const homeSchema = buildHomeSchema({
             <div class="popular-carousel" role="list" tabindex="0" aria-label="Most Popular recipes">
             {popularNotebooks.map((notebook) => (
               <div class="popular-card-wrapper" role="listitem">
-                <NotebookCard notebook={notebook} popularityCount={notebook.popularityCount} />
+                <NotebookCard notebook={notebook} viewCount={notebook.viewCount} />
               </div>
             ))}
             </div>
@@ -182,7 +185,7 @@ const homeSchema = buildHomeSchema({
               data-date={notebook.date ?? ""}
               data-tags={(notebook.tags ?? []).join(",")}
               data-title={notebook.title}
-              data-views={popularityBySlug.get(notebook.slug) ?? 0}
+              data-views={viewsBySlug.get(notebook.slug) ?? 0}
             >
               <NotebookCard notebook={notebook} />
             </div>

--- a/site/tests/navigation.spec.ts
+++ b/site/tests/navigation.spec.ts
@@ -65,6 +65,7 @@ test.describe("Site Navigation", () => {
 
     const catalog = page.getByRole("region", { name: /All/ });
     const collection = page.locator("#notebooks-grid");
+    const recipeCount = await collection.locator(".notebook-card-wrapper").count();
 
     await expect(collection).toHaveAttribute("data-view", "grid");
     await catalog.getByRole("button", { name: "List view" }).click();
@@ -72,7 +73,10 @@ test.describe("Site Navigation", () => {
 
     await catalog.getByRole("button", { name: "Sort by views" }).click();
     await expect(catalog.getByRole("button", { name: "Sort by views" })).toHaveAttribute("aria-pressed", "true");
-    await expect(collection.locator(".notebook-card-wrapper").first()).toHaveAttribute("data-views", "19");
+    const sortedViews = await collection.locator(".notebook-card-wrapper").evaluateAll((cards) =>
+      cards.map((card) => Number((card as HTMLElement).dataset.views ?? 0)),
+    );
+    expect(sortedViews[0]).toBe(Math.max(...sortedViews));
 
     await catalog.locator("summary[aria-label='Filter tags']").click();
     const tagCheckboxes = catalog.locator("[data-tag-checkbox]");
@@ -83,7 +87,7 @@ test.describe("Site Navigation", () => {
     await expect(page.locator("#recipe-count")).toHaveText("(1)");
 
     await catalog.getByRole("button", { name: "Clear tag filters" }).click();
-    await expect(page.locator("#recipe-count")).toHaveText("(13)");
+    await expect(page.locator("#recipe-count")).toHaveText(`(${recipeCount})`);
     await expect(catalog.getByRole("button", { name: "Clear tag filters" })).toBeHidden();
   });
 


### PR DESCRIPTION
## Summary
- rank the Popular carousel by trailing-30-day production recipe page views
- display production page views since Forgebook launched on June 2, 2026
- exclude localhost, PR previews, non-recipe routes, and unpublished registry slugs
- replace the stale committed fallback with a fresh snapshot generated July 16
- make navigation tests independent of daily-changing counters and recipe totals

## Validation
- `cd scripts && npx tsx validate-registry.ts`
- `cd site && npm run build`
- `cd site && npx playwright test tests/navigation.spec.ts --project=desktop`