### PR TITLE
chore(deps): separate major npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,9 @@ updates:
       site-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - dependencies
       - site
@@ -37,6 +40,9 @@ updates:
       script-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - dependencies
       - scripts


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Summary

- group only patch and minor npm updates for `site/` and `scripts/`
- leave major npm updates as separate Dependabot pull requests
- make compatibility failures easier to diagnose and review

## Validation

- parsed `.github/dependabot.yml` with PyYAML
- ran `git diff --check`